### PR TITLE
add missing region variable to `hello_world` pack

### DIFF
--- a/hello_world/variables.hcl
+++ b/hello_world/variables.hcl
@@ -2,6 +2,12 @@ variable "job_name" {
   description = "The name to use as the job name which overrides using the pack name."
   type        = string
   // If "", the pack name will be used
+  default = ""
+}
+
+variable "region" {
+  description = "The region where jobs will be deployed."
+  type        = string
   default     = ""
 }
 
@@ -27,7 +33,7 @@ variable "consul_service_tags" {
   description = "The consul service name for the hello-world application."
   type        = list(string)
   // defaults to integrat with Fabio or Traefik
-  default     = [
+  default = [
     "urlprefix-/",
     "traefik.enable=true",
     "traefik.http.routers.http.rule=Path(`/myapp`)",


### PR DESCRIPTION
Without this variable the pack fails with the following error:

```console
$ nomad-pack run dev:hello_world@latest
! Failed To Process Pack

        Error:   failed to render hello_world/templates/hello-world.nomad.tpl: template: hello_world/templates/_helpers.tpl:14:12: executing "region" at <eq .hello_world.region "">: error calling eq: incompatible
types for comparison
        Type:    *errors.errorString
        Context:
                 - Pack Name: hello_world@latest
                 - Registry Name: dev
                 - Pack Path: /Users/laoqui/.nomad/packs/dev
                 - Pack Version: latest
                 - Deployment Name: hello_world@latest
```