### PR TITLE
prometheus: add initial Prometheus pack.

### DIFF
--- a/packs/prometheus/README.md
+++ b/packs/prometheus/README.md
@@ -1,0 +1,104 @@
+# Prometheus
+
+This pack can be used to run [Prometheus][prometheus] on your Nomad cluster. It currently supports
+being run by the [Docker][docker_driver] and allows for Prometheus to be configured in different
+ways.
+
+## Variables
+
+- `job_name` (string "") - The name to use as the job name which overrides using the pack name.
+- `datacenters` (list(string) ["dc1"]) - A list of datacenters in the region which are eligible for
+  task placement.
+- `region` (string "global") - The region where the job should be placed.
+- `namespace` (string "default") - The namespace where the job should be placed.
+- `constraints` (list(object)) - Constraints to apply to the entire job.
+- `prometheus_group_network` (object) - The Prometheus network configuration options.
+- `prometheus_task` (object) - Details configuration options for the Prometheus task.
+- `prometheus_task_app_prometheus_yaml` (string) - The Prometheus configuration to pass to the
+task. The default value includes scrape configuration for Nomad servers, Nomad client, and
+Prometheus.
+- `prometheus_task_resources` (object) - The resource to assign to the Prometheus task.
+- `prometheus_task_services` (object) - Configuration options of the Prometheus services and checks.
+
+### `constraints` List of Objects
+
+[Nomad job specification constraints][job_constraint] allows restricting the set of eligible nodes
+on which the Prometheus task will run.
+
+- `attribute` (string) - Specifies the name or reference of the attribute to examine for the
+constraint.
+- `operator` (string) - Specifies the comparison operator. The ordering is compared lexically.
+- `value` (string) - Specifies the value to compare the attribute against using the specified
+operation.
+
+The default value constrains the job to run on client whose kernel name is `linux`. The HCL
+variable list of objects is shown below and uses a double dollar sign for escaping:
+```hcl
+[
+  {
+    attribute = "$${attr.kernel.name}",
+    value     = "linux",
+    operator  = "",
+  }
+]
+```
+
+### `prometheus_group_network` Object
+
+- `mode` (string "bridge") - Mode of the network.
+- `ports` (map<string|number> http:9090) - Specifies the port mapping for the Prometheus task. The
+map key indicates the port label, and the value is the Prometheus port inside the network namespace.
+
+### `prometheus_task` Object
+
+- `driver` (string "docker") - The Nomad task driver to use to run the Prometheus task. Currently,
+only "docker" is supported.
+- `version` (string "2.30.2") - The Prometheus version to run.
+- `cli_args` (list(string) "<see_below>") - A list of CLI arguments to pass to Prometheus.
+
+The default CLI arguments pass to Prometheus:
+```hcl
+[
+  "--config.file=/etc/prometheus/config/prometheus.yml",
+  "--storage.tsdb.path=/prometheus",
+  "--web.listen-address=0.0.0.0:9090",
+  "--web.console.libraries=/usr/share/prometheus/console_libraries",
+  "--web.console.templates=/usr/share/prometheus/consoles",
+]
+```
+
+### `prometheus_task_resources` Object
+
+-`cpu` (number 500) - Specifies the CPU required to run this task in MHz.
+-`memory` (number 256) - Specifies the memory required in MB.
+
+### `prometheus_task_services` List of Objects
+
+- `service_port_label` (string) - Specifies the port to advertise for this service.
+- `service_name` (string) - Specifies the name this service will be advertised as in Consul.
+- `service_tags` (list(string)) - Specifies the list of tags to associate with this service.
+- `check_enabled` (bool) - Whether to enable a check for this service.
+- `check_path` (string) - The HTTP path to query Prometheus.
+- `check_interval` (string) - Specifies the frequency of the health checks that Consul will perform.
+- `check_timeout` (string) - Specifies how long Consul will wait for a health check query to succeed.
+
+The default value for this variable configures a service for the Prometheus API along with a check
+running against the Prometheus [management API][prometheus_management_api] health check endpoint.
+```hcl
+[
+  {
+    service_port_label = "http",
+    service_name       = "prometheus",
+    service_tags       = [],
+    check_enabled      = true,
+    check_path         = "/-/healthy",
+    check_interval     = "3s",
+    check_timeout      = "1s",
+  }
+]
+```
+
+[prometheus]: (https://prometheus.io/)
+[prometheus_management_api]: (https://prometheus.io/docs/prometheus/latest/management_api/)
+[docker_driver]: (https://www.nomadproject.io/docs/drivers/docker)
+[job_constraint]: (https://www.nomadproject.io/docs/job-specification/constraint)

--- a/packs/prometheus/metadata.hcl
+++ b/packs/prometheus/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = "https://prometheus.io/"
+  author = "Prometheus"
+}
+
+pack {
+  name        = "prometheus"
+  description = "Prometheus is used to collect telemetry data and make it queryable."
+  url         = "https://github.com/hashicorp/nomad-pack-community-registry/tree/main/prometheus"
+  version     = "0.0.1"
+}

--- a/packs/prometheus/templates/_helpers.tpl
+++ b/packs/prometheus/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+[[- define "full_job_name" -]]
+[[- if eq .prometheus.job_name "" -]]
+[[- .nomad_pack.pack.name | quote -]]
+[[- else -]]
+[[- .prometheus.job_name | quote -]]
+[[- end -]]
+[[- end -]]

--- a/packs/prometheus/templates/prometheus.nomad.tpl
+++ b/packs/prometheus/templates/prometheus.nomad.tpl
@@ -1,0 +1,67 @@
+job [[ template "full_job_name" . ]] {
+
+  region      = [[ .prometheus.region | quote ]]
+  datacenters = [ [[ range $idx, $dc := .prometheus.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  namespace   = [[ .prometheus.namespace | quote ]]
+
+  group "prometheus" {
+
+    network {
+      mode = [[ .prometheus.prometheus_group_network.mode | quote ]]
+      [[- range $label, $to := .prometheus.prometheus_group_network.ports ]]
+      port [[ $label | quote ]] {
+        to = [[ $to ]]
+      }
+      [[- end ]]
+    }
+
+    task "prometheus" {
+      driver = "docker"
+
+      config {
+        image = "prom/prometheus:v[[ .prometheus.prometheus_task.version ]]"
+
+        args = [ [[ range $idx, $dc := .prometheus.prometheus_task.cli_args ]][[if $idx]],[[end]][[ $dc | quote ]]
+        [[end]] ]
+
+        volumes = [
+          "local/config:/etc/prometheus/config",
+        ]
+      }
+
+[[- if ne .prometheus.prometheus_task_app_prometheus_yaml "" ]]
+      template {
+        data = <<EOH
+[[ .prometheus.prometheus_task_app_prometheus_yaml ]]
+EOH
+
+        change_mode   = "signal"
+        change_signal = "SIGHUP"
+        destination   = "local/config/prometheus.yml"
+      }
+[[- end ]]
+
+      resources {
+        cpu    = [[ .prometheus.prometheus_task_resources.cpu ]]
+        memory = [[ .prometheus.prometheus_task_resources.memory ]]
+      }
+
+      [[- if .prometheus.prometheus_task_services ]]
+      [[- range $idx, $service := .prometheus.prometheus_task_services ]]
+      service {
+        name = [[ $service.service_name | quote ]]
+        port = [[ $service.service_port_label | quote ]]
+        tags = [ [[ range $idx, $dc := $service.service_tags ]][[if $idx]],[[end]][[ $dc | quote ]][[end]] ]
+
+        check {
+          type     = "http"
+          path     = [[ $service.check_path | quote ]]
+          interval = [[ $service.check_interval | quote ]]
+          timeout  = [[ $service.check_timeout | quote ]]
+        }
+      }
+      [[- end ]]
+      [[- end ]]
+    }
+  }
+}

--- a/packs/prometheus/variables.hcl
+++ b/packs/prometheus/variables.hcl
@@ -1,0 +1,144 @@
+variable "job_name" {
+  description = "The name to use as the job name which overrides using the pack name."
+  type        = string
+  default     = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for job placement."
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "region" {
+  description = "The region where the job should be placed."
+  type        = string
+  default     = "global"
+}
+
+variable "namespace" {
+  description = "The namespace where the job should be placed."
+  type        = string
+  default     = "default"
+}
+
+variable "constraints" {
+  description = "Constraints to apply to the entire job."
+  type        = list(object({
+    attribute = string
+    operator  = string
+    value     = string
+  }))
+  default = [
+    {
+      attribute = "$${attr.kernel.name}",
+      value     = "linux",
+      operator  = "",
+    },
+  ]
+}
+
+variable "prometheus_group_network" {
+  description = "The Prometheus network configuration options."
+  type        = object({
+    mode  = string
+    ports = map(number)
+  })
+  default = {
+    mode  = "bridge",
+    ports = {
+      "http" = 9090,
+    },
+  }
+}
+
+variable "prometheus_task" {
+  description = "Details configuration options for the Prometheus task."
+  type        = object({
+    driver   = string
+    version  = string
+    cli_args = list(string)
+  })
+  default = {
+    driver   = "docker",
+    version  = "2.30.2",
+    cli_args = [
+      "--config.file=/etc/prometheus/config/prometheus.yml",
+      "--storage.tsdb.path=/prometheus",
+      "--web.listen-address=0.0.0.0:9090",
+      "--web.console.libraries=/usr/share/prometheus/console_libraries",
+      "--web.console.templates=/usr/share/prometheus/consoles",
+    ]
+  }
+}
+
+variable "prometheus_task_app_prometheus_yaml" {
+  description = "The Prometheus configuration to pass to the task."
+  type        = string
+  default     = <<EOF
+---
+global:
+  scrape_interval: 30s
+  evaluation_interval: 3s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+    - targets:
+      - 0.0.0.0:9090
+  - job_name: "nomad_server"
+    metrics_path: "/v1/metrics"
+    params:
+      format:
+      - "prometheus"
+    consul_sd_configs:
+    - server: "{{ env "attr.unique.network.ip-address" }}:8500"
+      services:
+        - "nomad"
+      tags:
+        - "http"
+  - job_name: "nomad_client"
+    metrics_path: "/v1/metrics"
+    params:
+      format:
+      - "prometheus"
+    consul_sd_configs:
+    - server: "{{ env "attr.unique.network.ip-address" }}:8500"
+      services:
+        - "nomad-client"
+EOF
+}
+
+variable "prometheus_task_resources" {
+  description = "The resource to assign to the Prometheus task."
+  type        = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 500,
+    memory = 256,
+  }
+}
+
+variable "prometheus_task_services" {
+  description = "Configuration options of the Prometheus services and checks."
+  type        = list(object({
+    service_port_label = string
+    service_name       = string
+    service_tags       = list(string)
+    check_enabled      = bool
+    check_path         = string
+    check_interval     = string
+    check_timeout      = string
+  }))
+  default = [{
+    service_port_label = "http",
+    service_name       = "prometheus",
+    service_tags       = [],
+    check_enabled      = true,
+    check_path         = "/-/healthy",
+    check_interval     = "3s",
+    check_timeout      = "1s",
+  }]
+}


### PR DESCRIPTION
This initial Prometheus pack provides a way of running and
configuring a Prometheus server. The default yaml provides scrape
targets for Nomad and Prometheus but does assume Consul is running
on the same private IP as Nomad.

closes #12 