### PR TITLE
Add Caasperli Pack

### DIFF
--- a/packs/caasperli/README.md
+++ b/packs/caasperli/README.md
@@ -1,0 +1,30 @@
+# Caasperli Nomad Pack
+
+This is a pack for [Caasperli](https://github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape), a simple container used for demonstration purposes.
+
+## How to Run this Nomad Pack
+
+Start a [Nomad dev agent](https://learn.hashicorp.com/tutorials/nomad/get-started-run?in=nomad/get-started) (if needed):
+```bash
+$ nomad agent -dev
+```
+
+To run the pack:
+```bash
+$ nomad-pack run . --var static_port=8080
+```
+
+The Caasperli app can be accessed on http://127.0.0.1:8080.
+
+To destroy the pack:
+```bash
+$ nomad-pack destroy .
+```
+
+## Variables
+
+- `job_name` (string) - The name to use as the job name which overrides using the pack name
+- `region` (string) - The region where jobs will be deployed
+- `datacenters` (list of strings) - A list of datacenters in the region which are eligible for task placement
+- `count` (number) - The number of app instances to deploy
+- `static_port` (number) - The static port for exposing the app service. If defined, exposes the app service on `static_port`.

--- a/packs/caasperli/README.md
+++ b/packs/caasperli/README.md
@@ -11,14 +11,14 @@ $ nomad agent -dev
 
 To run the pack:
 ```bash
-$ nomad-pack run . --var static_port=8080
+$ nomad-pack run caasperli --var static_port=8080
 ```
 
 The Caasperli app can be accessed on http://127.0.0.1:8080.
 
 To destroy the pack:
 ```bash
-$ nomad-pack destroy .
+$ nomad-pack destroy caasperli
 ```
 
 ## Variables

--- a/packs/caasperli/metadata.hcl
+++ b/packs/caasperli/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url = "https://github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape"
+  author = "Adfinis"
+}
+
+pack {
+  name = "caasperli"
+  description = "A simple container used for demonstration purposes"
+  url = "https://github.com/adfinis-sygroup/caasperli-nomad-pack"
+  version = "0.0.1"
+}

--- a/packs/caasperli/outputs.tpl
+++ b/packs/caasperli/outputs.tpl
@@ -1,0 +1,3 @@
+Potz Holzöpfel und Zipfelchape! You just deployed [[ .nomad_pack.pack.name ]], a simple container used for demonstration purposes.
+
+There are [[ .caasperli.count ]] instances of your job now running on Nomad.

--- a/packs/caasperli/templates/_helpers.tpl
+++ b/packs/caasperli/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+// allow nomad-pack to set the job name
+
+[[- define "job_name" -]]
+[[- if eq .caasperli.job_name "" -]]
+[[- .nomad_pack.pack.name | quote -]]
+[[- else -]]
+[[- .caasperli.job_name | quote -]]
+[[- end -]]
+[[- end -]]
+
+// only deploys to a region if specified
+
+[[- define "region" -]]
+[[- if not (eq .caasperli.region "") -]]
+region = [[ .caasperli.region | quote]]
+[[- end -]]
+[[- end -]]
+
+// expose app service on static port if static_port is defined
+
+[[- define "network" -]]
+[[- if not (eq .caasperli.static_port -1) -]]
+    network {
+      port "http" {
+        to = 8080
+        static = [[ .caasperli.static_port ]]
+      }
+    }
+[[- end -]]
+[[- end -]]
+
+[[- define "ports" -]]
+[[- if not (eq .caasperli.static_port -1) -]]
+        ports = ["http"]
+[[- end -]]
+[[- end -]]

--- a/packs/caasperli/templates/caasperli.nomad.tpl
+++ b/packs/caasperli/templates/caasperli.nomad.tpl
@@ -1,0 +1,27 @@
+job [[ template "job_name" . ]] {
+  [[ template "region" . ]]
+  datacenters = [ [[ range $idx, $dc := .caasperli.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  type = "service"
+
+  group "app" {
+    count = [[ .caasperli.count ]]
+
+    [[ template "network" . ]]
+
+    restart {
+      attempts = 2
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/adfinis-sygroup/potz-holzoepfel-und-zipfelchape"
+        [[ template "ports" . ]]
+      }
+    }
+  }
+}

--- a/packs/caasperli/variables.hcl
+++ b/packs/caasperli/variables.hcl
@@ -1,0 +1,31 @@
+variable "job_name" {
+  description = "The name to use as the job name which overrides using the pack name"
+  type        = string
+  // If "", the pack name will be used
+  default = ""
+}
+
+variable "region" {
+  description = "The region where jobs will be deployed"
+  type        = string
+  default     = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement"
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "count" {
+  description = "The number of app instances to deploy"
+  type        = number
+  default     = 1
+}
+
+variable "static_port" {
+  description = "The static port for exposing the app service"
+  type        = number
+  // If -1, static port is disabled and app service port is not exposed on the host. 
+  default     = -1
+}


### PR DESCRIPTION
This change adds a Nomad Pack for [Caasperli](https://github.com/adfinis-sygroup/potz-holzoepfel-und-zipfelchape), a simple container used for demonstration purposes..