### PR TITLE
Proposal of simplification of list generators in templates

### DIFF
--- a/packs/fabio/templates/fabio.nomad.tpl
+++ b/packs/fabio/templates/fabio.nomad.tpl
@@ -1,7 +1,7 @@
 job [[ template "job_name" . ]] {
 
   region      = [[ .fabio.region | quote]]
-  datacenters = [ [[ range $idx, $dc := .fabio.datacenters ]][[if $idx]], [[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .fabio.datacenters | toPrettyJson ]]
   type        = "system"
   namespace   = [[ .fabio.namespace | quote]]
   [[ if .fabio.constraints ]][[ range $idx, $constraint := .fabio.constraints ]]
@@ -31,7 +31,7 @@ job [[ template "job_name" . ]] {
         image = "fabiolb/fabio:[[ .fabio.fabio_task_config.version ]]"
         [[- if .fabio.fabio_group_network.ports ]]
         [[- $ports := keys .fabio.fabio_group_network.ports ]]
-        ports = [ [[ range $idx, $label := $ports ]][[if $idx]], [[end]][[ $label | quote ]][[ end ]] ]
+        ports = [[ $ports | toPrettyJson ]]
         [[- end ]]
 
         [[- if ne .fabio.fabio_task_app_properties "" ]]

--- a/packs/grafana/templates/grafana.nomad.tpl
+++ b/packs/grafana/templates/grafana.nomad.tpl
@@ -1,6 +1,6 @@
 job [[ template "job_name" . ]] {
   [[ template "region" . ]]
-  datacenters = [ [[ range $idx, $dc := .grafana.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .grafana.datacenters | toPrettyJson ]]
 
   // must have linux for network mode
   constraint {

--- a/packs/haproxy/templates/haproxy.nomad.tpl
+++ b/packs/haproxy/templates/haproxy.nomad.tpl
@@ -1,6 +1,6 @@
 job [[ template "job_name" . ]] {
   [[ template "region" . ]]
-  datacenters = [ [[ range $idx, $dc := .haproxy.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .haproxy.datacenters | toPrettyJson ]]
 
   type        = "service"
 

--- a/packs/hello_world/templates/hello_world.nomad.tpl
+++ b/packs/hello_world/templates/hello_world.nomad.tpl
@@ -1,6 +1,6 @@
 job [[ template "job_name" . ]] {
   [[ template "region" . ]]
-  datacenters = [[ .hello_world.datacenters | toJson ]]
+  datacenters = [[ .hello_world.datacenters | toPrettyJson ]]
   type = "service"
 
   group "app" {
@@ -15,7 +15,7 @@ job [[ template "job_name" . ]] {
     [[ if .hello_world.register_consul_service ]]
     service {
       name = "[[ .hello_world.consul_service_name ]]"
-      tags = [[ .hello_world.consul_service_tags | toJson ]]
+      tags = [[ .hello_world.consul_service_tags | toPrettyJson ]]
       port = "http"
 
       check {

--- a/packs/loki/templates/loki.nomad.tpl
+++ b/packs/loki/templates/loki.nomad.tpl
@@ -1,6 +1,6 @@
 job [[ template "job_name" . ]] {
   [[ template "region" . ]]
-  datacenters = [ [[ range $idx, $dc := .loki.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .loki.datacenters | toPrettyJson ]]
 
   // must have linux for network mode
   constraint {

--- a/packs/nginx/templates/nginx.nomad.tpl
+++ b/packs/nginx/templates/nginx.nomad.tpl
@@ -1,6 +1,6 @@
 job [[ template "job_name" . ]] {
   [[ template "region" . ]]
-  datacenters = [ [[ range $idx, $dc := .nginx.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .nginx.datacenters | toPrettyJson ]]
 
   // must have linux for network mode
   constraint {

--- a/packs/nomad_autoscaler/templates/_helpers.tpl
+++ b/packs/nomad_autoscaler/templates/_helpers.tpl
@@ -10,5 +10,5 @@
 [[- $fullArgs := prepend .nomad_autoscaler.autoscaler_agent_task.additional_cli_args "agent" -]]
 [[- if .nomad_autoscaler.autoscaler_agent_task.scaling_policy_files ]][[ $fullArgs = append $fullArgs "-policy-dir=${NOMAD_TASK_DIR}/policies" ]][[- end -]]
 [[- if .nomad_autoscaler.autoscaler_agent_task.config_files ]][[ $fullArgs = append $fullArgs "-config=${NOMAD_TASK_DIR}/config" ]][[- end -]]
-[ [[ range $idx, $arg := $fullArgs ]][[if $idx]],[[end]][[ $arg | quote ]][[ end ]] ]
+[[ $fullArgs | toPrettyJson ]]
 [[- end -]]

--- a/packs/nomad_autoscaler/templates/nomad_autoscaler.nomad.tpl
+++ b/packs/nomad_autoscaler/templates/nomad_autoscaler.nomad.tpl
@@ -1,7 +1,7 @@
 job [[ template "full_job_name" . ]] {
 
   region      = [[ .nomad_autoscaler.region | quote ]]
-  datacenters = [ [[ range $idx, $dc := .nomad_autoscaler.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .nomad_autoscaler.datacenters | toPrettyJson ]]
   namespace   = [[ .nomad_autoscaler.namespace | quote ]]
 
   group "autoscaler" {
@@ -67,7 +67,7 @@ job [[ template "full_job_name" . ]] {
       service {
         name = [[ .nomad_autoscaler.autoscaler_agent_task_service.service_name | quote ]]
         port = [[ .nomad_autoscaler.autoscaler_agent_network.autoscaler_http_port_label | quote ]]
-        tags = [ [[ range $idx, $tag := .nomad_autoscaler.autoscaler_agent_task_service.service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+        tags = [[ .nomad_autoscaler.autoscaler_agent_task_service.service_tags | toPrettyJson ]]
 
         check {
           type     = [[ .nomad_autoscaler.autoscaler_agent_network.autoscaler_http_port_label | quote ]]

--- a/packs/prometheus/templates/prometheus.nomad.tpl
+++ b/packs/prometheus/templates/prometheus.nomad.tpl
@@ -1,7 +1,7 @@
 job [[ template "full_job_name" . ]] {
 
   region      = [[ .prometheus.region | quote ]]
-  datacenters = [ [[ range $idx, $dc := .prometheus.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .prometheus.datacenters | toPrettyJson ]]
   namespace   = [[ .prometheus.namespace | quote ]]
   [[ if .prometheus.constraints ]][[ range $idx, $constraint := .prometheus.constraints ]]
   constraint {
@@ -29,10 +29,7 @@ job [[ template "full_job_name" . ]] {
 
       config {
         image = "prom/prometheus:v[[ .prometheus.prometheus_task.version ]]"
-
-        args = [ [[ range $idx, $dc := .prometheus.prometheus_task.cli_args ]][[if $idx]],[[end]][[ $dc | quote ]]
-        [[end]] ]
-
+        args = [[ .prometheus.prometheus_task.cli_args | toPrettyJson ]]
         volumes = [
           "local/config:/etc/prometheus/config",
         ]
@@ -60,7 +57,7 @@ EOH
       service {
         name = [[ $service.service_name | quote ]]
         port = [[ $service.service_port_label | quote ]]
-        tags = [ [[ range $idx, $dc := $service.service_tags ]][[if $idx]],[[end]][[ $dc | quote ]][[end]] ]
+        tags = [[ $service.service_tags | toPrettyJson ]]
 
         check {
           type     = "http"

--- a/packs/prometheus_node_exporter/templates/prometheus_node_exporter.nomad.tpl
+++ b/packs/prometheus_node_exporter/templates/prometheus_node_exporter.nomad.tpl
@@ -1,7 +1,7 @@
 job [[ template "job_name" . ]] {
 
   region      = [[ .prometheus_node_exporter.region | quote]]
-  datacenters = [ [[ range $idx, $dc := .prometheus_node_exporter.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .prometheus_node_exporter.datacenters | toPrettyJson ]]
   type        = "system"
   [[ if .prometheus_node_exporter.constraints ]][[ range $idx, $constraint := .prometheus_node_exporter.constraints ]]
   constraint {
@@ -45,7 +45,7 @@ job [[ template "job_name" . ]] {
       service {
         name = [[ $service.service_name | quote ]]
         port = [[ $service.service_port_label | quote ]]
-        tags = [ [[ range $idx, $tag := $service.service_tags ]][[if $idx]], [[end]][[ $tag | quote ]][[ end ]] ]
+        tags = [[ $service.service_tags | toPrettyJson ]]
 
         [[- if $service.check_enabled ]]
         check {

--- a/packs/simple_service/templates/simple_service.nomad.tpl
+++ b/packs/simple_service/templates/simple_service.nomad.tpl
@@ -1,6 +1,6 @@
 job [[ template "job_name" . ]] {
   [[ template "region" . ]]
-  datacenters = [ [[ range $idx, $dc := .simple_service.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .simple_service.datacenters | toPrettyJson ]]
   type = "service"
 
   group "app" {
@@ -18,7 +18,7 @@ job [[ template "job_name" . ]] {
     service {
       name = "[[ .simple_service.consul_service_name ]]"
       port = "[[ .simple_service.consul_service_port ]]"
-      tags = [ [[ range $idx, $tag := .simple_service.consul_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+      tags = [[ .simple_service.consul_tags | toPrettyJson ]]
 
       connect {
         sidecar_service {

--- a/packs/traefik/templates/traefik.nomad.tpl
+++ b/packs/traefik/templates/traefik.nomad.tpl
@@ -1,7 +1,7 @@
 job [[ template "job_name" . ]] {
 
   region      = [[ .traefik.region | quote]]
-  datacenters = [ [[ range $idx, $dc := .traefik.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .traefik.datacenters | toPrettyJson ]]
   type        = "system"
   [[ if .traefik.constraints ]][[ range $idx, $constraint := .traefik.constraints ]]
   constraint {
@@ -33,7 +33,7 @@ job [[ template "job_name" . ]] {
         image = "traefik:[[ .traefik.traefik_task.version ]]"
         [[- if .traefik.traefik_group_network.ports ]]
         [[- $ports := keys .traefik.traefik_group_network.ports ]]
-        ports = [ [[ range $idx, $label := $ports ]][[if $idx]],[[end]][[ $label | quote ]][[ end ]] ]
+        ports = [[ $ports | toPrettyJson ]]
         [[- end ]]
         [[- end ]]
 


### PR DESCRIPTION
Hello!

I'd like to propose a cleaner way of generating lists in templates. First, I did it in `hello_world` template to start a discussion about this approach. If community agree with this method and won't find any possible problems, we can do the same thing across all templates.

In original code you did loop on list, then checked if it's not last element and then printed comma and value in quote:

```hcl
datacenters = [ [[ range $idx, $dc := .hello_world.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
```

I think we should use safer (in the meaning of char escaping) `toJson` function from [Masterminds/sprig](https://github.com/Masterminds/sprig) included in `nomad-pack` binary.

So above code with if and loop can change to:

```hcl
datacenters = [[ .hello_world.datacenters | toJson ]]
```

In output render, we will have two spaces less:

```diff
-  datacenters = [ "dc1" ]
+  datacenters = ["dc1"]
```


