### PR TITLE
Pack: WordPress

### DIFF
--- a/packs/wordpress/README.md
+++ b/packs/wordpress/README.md
@@ -1,0 +1,176 @@
+# WordPress
+
+This pack contains a service job that runs [WordPress](https://wordpress.org/) in a single Nomad client. It currently supports
+being run by the [Docker](https://www.nomadproject.io/docs/drivers/docker) driver.
+
+It has 3 tasks:
+- **WordPress:** [*(reference)*](https://wordpress.org/) the open-source CMS;
+- **MariaDB:** [*(reference)*](https://mariadb.org/) the database used by Wordpress;
+- **phpMyAdmin:** [*(reference)*](https://www.phpmyadmin.net/) to handle the administration of MariaDB over web.
+
+Setup:
+- Service-to-service communication is handled with Consul Connect (via sidecar proxies);
+- MariaDB's state is persisted with Nomad Host Volumes;
+- Consul service registration and service health checks are enabled by default for WordPress and phpMyAdmin. MariaDB only has service registration enabled.
+
+## Requirements
+Clients that expect to run this job require:
+- [Docker volumes](https://www.nomadproject.io/docs/drivers/docker "Docker volumes") to be enabled within their Docker plugin stanza, due to the usage of Nomad's host volume:
+```hcl
+plugin "docker" {
+  config {
+    volumes {
+      enabled = true
+    }
+  }
+}
+```
+
+- [Host volume](https://www.nomadproject.io/docs/configuration/client#host_volume-stanza "Host volume") to be enabled in the client configuration (the host volume directory - /var/lib/mariadb - must be created in advance):
+```hcl
+client {
+  host_volume "wordpress-mariadb" {
+    path      = "/var/lib/mariadb"
+    read_only = false
+  }
+}
+```
+
+- [CNI plugins installed](https://www.nomadproject.io/docs/job-specification/network#network-modes "CNI plugins installed") and [its path](https://www.nomadproject.io/docs/configuration/client#cni_path "its path") set in the client's configuration if network mode is set to bridge.
+
+- [Consul Connect](https://www.nomadproject.io/docs/integrations/consul-connect "Consul Connect") to be enabled in Consul's configuration:
+```hcl
+ports {
+  grpc = 8502
+}
+
+connect {
+  enabled = true
+}
+```
+
+## Customizing the Docker images
+
+The 3 docker images can be replaced by using their variable names:
+- mariadb_task_image
+- wordpress_task_image
+- phpmyadmin_task_image
+
+Example:
+```
+nomad-pack run wordpress --var wordpress_task_image="wordpress:5.8.1-apache"
+```
+
+## Customizing the environment variables
+
+The 3 tasks have default environment variables. However, it's recommended to change the ones related to authentication if the services are going to be publicly accessible. Additional environment variables can be passed to nomad-pack, even if not in the default variables file.
+
+Default MariaDB environment variables:
+```
+mariadb_task_env_vars = [
+  {
+    key = "MYSQL_ROOT_PASSWORD"
+    value = "mariadb_root_password"
+  },
+  {
+    key = "MYSQL_DATABASE"
+    value = "wordpress"
+  },
+  {
+    key = "MYSQL_USER"
+    value = "wordpress"
+  },
+  {
+    key = "MYSQL_PASSWORD"
+    value = "wordpress"
+  }
+]
+```
+
+Default WordPress environment variables:
+```
+wordpress_task_env_vars = [
+  {
+    key = "WORDPRESS_DB_HOST"
+    value = "$${NOMAD_UPSTREAM_ADDR_mariadb}"
+  },
+  {
+    key = "WORDPRESS_DB_USER"
+    value = "wordpress"
+  },
+  {
+    key = "WORDPRESS_DB_PASSWORD"
+    value = "wordpress"
+  },
+  {
+    key = "WORDPRESS_DB_NAME"
+    value = "wordpress"
+  }
+]
+```
+
+Default phpMyAdmin environment variables:
+```
+phpmyadmin_task_env_vars = [
+  {
+    key = "MYSQL_ROOT_PASSWORD"
+    value = "mariadb_root_password"
+  },
+  {
+    key = "PMA_HOST"
+    value = "$${NOMAD_UPSTREAM_IP_mariadb}"
+  },
+  {
+    key = "PMA_PORT"
+    value = "$${NOMAD_UPSTREAM_PORT_mariadb}"
+  },
+  {
+    key = "MYSQL_USERNAME"
+    value = "wordpress"
+  }
+]
+```
+
+## Customizing Ports
+
+MariaDB ports are not exposed and communication to it needs to be done via its sidecar proxy.
+
+WordPress and phpMyAdmin port 80 are exposed and are randomly assigned to the host. The usage of a reverse proxy, such as Traefik, is recommended.
+
+## Customizing Resources
+
+The application resource limits can be customized on a task level. The variables names are:
+- mariadb_task_resources
+- wordpress_task_resources
+- phpmyadmin_task_resources
+
+Example:
+```
+wordpress_task_resources = {
+  cpu = 1024
+  memory = 2048
+}
+```
+
+## Customizing service health checks
+
+Health checks can be disabled on a service basis. Setting the following variables to *false* will completely disable health checks:
+- mariadb_group_has_health_check
+- wordpress_group_has_health_check
+- phpmyadmin_group_has_health_check
+
+Health check configuration is set by the following variables:
+- mariadb_group_health_check
+- wordpress_group_health_check
+- phpmyadmin_group_health_check
+
+Example:
+```
+wordpress_group_health_check = {
+  name     = "wordpress"
+  path     = "/wp-admin/install.php"
+  port     = "http"
+  interval = "10s"
+  timeout  = "2s"
+}
+```

--- a/packs/wordpress/metadata.hcl
+++ b/packs/wordpress/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = "https://wordpress.org/"
+  author = "WordPress contributors"
+}
+
+pack {
+  name        = "wordpress"
+  description = "WordPress - Open-source CMS"
+  url         = "https://github.com/hashicorp/nomad-pack-community-registry/wordpress"
+  version     = "0.0.1"
+}

--- a/packs/wordpress/templates/_helpers.tpl
+++ b/packs/wordpress/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+// allow nomad-pack to set the job name
+
+[[- define "job_name" -]]
+[[- if eq .wordpress.job_name "" -]]
+[[- .nomad_pack.pack.name | quote -]]
+[[- else -]]
+[[- .wordpress.job_name | quote -]]
+[[- end -]]
+[[- end -]]
+
+// only deploys to a region if specified
+
+[[- define "region" -]]
+[[- if not (eq .wordpress.region "") -]]
+region = [[ .wordpress.region | quote]]
+[[- end -]]
+[[- end -]]

--- a/packs/wordpress/templates/wordpress.nomad.tpl
+++ b/packs/wordpress/templates/wordpress.nomad.tpl
@@ -57,9 +57,12 @@ job [[ template "job_name" . ]] {
 
       config {
         image = [[.wordpress.mariadb_task_image | quote]]
-        volumes = [
-          "[[.wordpress.mariadb_task_volume_path]]:/var/lib/mysql",
-        ]
+      }
+      
+      volume_mount {
+        volume      = "mariadb"
+        destination = "/var/lib/mysql"
+        read_only   = false
       }
 
       [[- $mariadb_task_env_vars_length := len .wordpress.mariadb_task_env_vars ]]

--- a/packs/wordpress/templates/wordpress.nomad.tpl
+++ b/packs/wordpress/templates/wordpress.nomad.tpl
@@ -1,0 +1,249 @@
+job [[ template "job_name" . ]] {
+  [[ template "region" . ]]
+  datacenters = [ [[ range $idx, $dc := .wordpress.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  type = "service"
+
+  group "mariadb" {
+    count = 1
+
+    network {
+      mode = "bridge"
+    }
+
+    update {
+      min_healthy_time  = [[ .wordpress.mariadb_group_update.min_healthy_time | quote ]]
+      healthy_deadline  = [[ .wordpress.mariadb_group_update.healthy_deadline | quote ]]
+      progress_deadline = [[ .wordpress.mariadb_group_update.progress_deadline | quote ]]
+      auto_revert       = [[ .wordpress.mariadb_group_update.auto_revert ]]
+    }
+
+    volume "mariadb" {
+      type = "host"
+      read_only = false
+      source = [[ .wordpress.mariadb_group_volume | quote ]]
+    }
+
+    [[- if .wordpress.mariadb_group_register_consul_service ]]
+    service {
+      name = [[ .wordpress.mariadb_group_consul_service_name | quote ]]
+      port = [[ .wordpress.mariadb_group_consul_service_port | quote ]]
+      tags = [ [[ range $idx, $tag := .wordpress.mariadb_group_consul_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+
+      connect {
+        sidecar_service {}
+      }
+
+      [[- if .wordpress.mariadb_group_has_health_check ]]
+      check {
+        name     = "mariadb"
+        type     = "tcp"
+        port     = [[ .wordpress.mariadb_group_health_check.port ]]
+        interval = [[ .wordpress.mariadb_group_health_check.interval | quote ]]
+        timeout  = [[ .wordpress.mariadb_group_health_check.timeout | quote ]]
+      }
+      [[- end ]]
+    }
+    [[- end ]]
+
+    restart {
+      attempts = [[ .wordpress.mariadb_group_restart_attempts ]]
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "mariadb" {
+      driver = "docker"
+
+      config {
+        image = [[.wordpress.mariadb_task_image | quote]]
+        volumes = [
+          "[[.wordpress.mariadb_task_volume_path]]:/var/lib/mysql",
+        ]
+      }
+
+      [[- $mariadb_task_env_vars_length := len .wordpress.mariadb_task_env_vars ]]
+      [[- if not (eq $mariadb_task_env_vars_length 0) ]]
+      env {
+        [[- range $var := .wordpress.mariadb_task_env_vars ]]
+        [[ $var.key ]] = [[ $var.value | quote ]]
+        [[- end ]]
+      }
+      [[- end ]]
+
+      resources {
+        cpu    = [[ .wordpress.mariadb_task_resources.cpu ]]
+        memory = [[ .wordpress.mariadb_task_resources.memory ]]
+      }
+    }
+  }
+
+  group "wordpress" {
+    count = 1
+
+    network {
+      mode = "bridge"
+      [[- range $port := .wordpress.wordpress_group_network ]]
+      port [[ $port.name | quote ]] {
+        to = [[ $port.port ]]
+      }
+      [[- end ]]
+    }
+
+    update {
+      min_healthy_time  = [[ .wordpress.wordpress_group_update.min_healthy_time | quote ]]
+      healthy_deadline  = [[ .wordpress.wordpress_group_update.healthy_deadline | quote ]]
+      progress_deadline = [[ .wordpress.wordpress_group_update.progress_deadline | quote ]]
+      auto_revert       = [[ .wordpress.wordpress_group_update.auto_revert ]]
+    }
+
+    [[- if .wordpress.wordpress_group_register_consul_service ]]
+    service {
+      name = [[ .wordpress.wordpress_group_consul_service_name | quote ]]
+      port = [[ .wordpress.wordpress_group_consul_service_port | quote ]]
+      tags = [ [[ range $idx, $tag := .wordpress.wordpress_group_consul_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+
+      connect {
+        sidecar_service {
+          proxy {
+            [[- range $upstream := .wordpress.wordpress_group_upstreams ]]
+            upstreams {
+              destination_name = [[ $upstream.name | quote ]]
+              local_bind_port  = [[ $upstream.port ]]
+            }
+            [[- end ]]
+          }
+        }
+      }
+
+      [[- if .wordpress.wordpress_group_has_health_check ]]
+      check {
+        name     = [[ .wordpress.wordpress_group_health_check.name | quote ]]
+        type     = "http"
+        port     = [[ .wordpress.wordpress_group_health_check.port | quote ]]
+        path     = [[ .wordpress.wordpress_group_health_check.path | quote ]]
+        interval = [[ .wordpress.wordpress_group_health_check.interval | quote ]]
+        timeout  = [[ .wordpress.wordpress_group_health_check.timeout | quote ]]
+      }
+      [[- end ]]
+    }
+    [[- end ]]
+
+    restart {
+      attempts = [[ .wordpress.wordpress_group_restart_attempts ]]
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "wordpress" {
+      driver = "docker"
+
+      config {
+        image = [[.wordpress.wordpress_task_image | quote]]
+      }
+
+      [[- $wordpress_task_env_vars_length := len .wordpress.wordpress_task_env_vars ]]
+      [[- if not (eq $wordpress_task_env_vars_length 0) ]]
+      env {
+        [[- range $var := .wordpress.wordpress_task_env_vars ]]
+        [[ $var.key ]] = [[ $var.value | quote ]]
+        [[- end ]]
+      }
+      [[- end ]]
+
+      resources {
+        cpu    = [[ .wordpress.wordpress_task_resources.cpu ]]
+        memory = [[ .wordpress.wordpress_task_resources.memory ]]
+      }
+    }
+  }
+
+
+
+
+
+
+
+
+  group "phpmyadmin" {
+    count = 1
+
+    network {
+      mode = "bridge"
+      [[- range $port := .wordpress.phpmyadmin_group_network ]]
+      port [[ $port.name | quote ]] {
+        to = [[ $port.port ]]
+      }
+      [[- end ]]
+    }
+
+    update {
+      min_healthy_time  = [[ .wordpress.phpmyadmin_group_update.min_healthy_time | quote ]]
+      healthy_deadline  = [[ .wordpress.phpmyadmin_group_update.healthy_deadline | quote ]]
+      progress_deadline = [[ .wordpress.phpmyadmin_group_update.progress_deadline | quote ]]
+      auto_revert       = [[ .wordpress.phpmyadmin_group_update.auto_revert ]]
+    }
+
+    [[- if .wordpress.phpmyadmin_group_register_consul_service ]]
+    service {
+      name = [[ .wordpress.phpmyadmin_group_consul_service_name | quote ]]
+      port = [[ .wordpress.phpmyadmin_group_consul_service_port | quote ]]
+      tags = [ [[ range $idx, $tag := .wordpress.phpmyadmin_group_consul_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+
+      connect {
+        sidecar_service {
+          proxy {
+            [[- range $upstream := .wordpress.phpmyadmin_group_upstreams ]]
+            upstreams {
+              destination_name = [[ $upstream.name | quote ]]
+              local_bind_port  = [[ $upstream.port ]]
+            }
+            [[- end ]]
+          }
+        }
+      }
+
+      [[- if .wordpress.phpmyadmin_group_has_health_check ]]
+      check {
+        name     = [[ .wordpress.phpmyadmin_group_health_check.name | quote ]]
+        type     = "http"
+        port     = [[ .wordpress.phpmyadmin_group_health_check.port | quote ]]
+        path     = [[ .wordpress.phpmyadmin_group_health_check.path | quote ]]
+        interval = [[ .wordpress.phpmyadmin_group_health_check.interval | quote ]]
+        timeout  = [[ .wordpress.phpmyadmin_group_health_check.timeout | quote ]]
+      }
+      [[- end ]]
+    }
+    [[- end ]]
+
+    restart {
+      attempts = [[ .wordpress.phpmyadmin_group_restart_attempts ]]
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "phpmyadmin" {
+      driver = "docker"
+
+      config {
+        image = [[.wordpress.phpmyadmin_task_image | quote]]
+      }
+
+      [[- $phpmyadmin_task_env_vars_length := len .wordpress.phpmyadmin_task_env_vars ]]
+      [[- if not (eq $phpmyadmin_task_env_vars_length 0) ]]
+      env {
+        [[- range $var := .wordpress.phpmyadmin_task_env_vars ]]
+        [[ $var.key ]] = [[ $var.value | quote ]]
+        [[- end ]]
+      }
+      [[- end ]]
+
+      resources {
+        cpu    = [[ .wordpress.phpmyadmin_task_resources.cpu ]]
+        memory = [[ .wordpress.phpmyadmin_task_resources.memory ]]
+      }
+    }
+  }
+}

--- a/packs/wordpress/variables.hcl
+++ b/packs/wordpress/variables.hcl
@@ -1,0 +1,431 @@
+// Job variables
+variable "job_name" {
+  description = "The name to use as the job name which overrides using the pack name"
+  type        = string
+  // If "", the pack name will be used
+  default = ""
+}
+
+variable "region" {
+  description = "The region where jobs will be deployed"
+  type        = string
+  default     = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement"
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+// MariaDB variables
+variable "mariadb_group_update" {
+  description = "The MariaDB update configuration options."
+  type        = object({
+    min_healthy_time  = string
+    healthy_deadline  = string
+    progress_deadline = string
+    auto_revert       = bool
+  })
+  default = {
+    min_healthy_time  = "10s",
+    healthy_deadline  = "5m",
+    progress_deadline = "10m",
+    auto_revert       = true,
+  }
+}
+
+variable "mariadb_group_volume" {
+  description = "The source volume name, as defined in Nomad's client configuration, to be used by MariaDB."
+  type        = string
+  default     = "wordpress-mariadb"
+}
+
+variable "mariadb_group_register_consul_service" {
+  description = "If you want to register a consul service for the job."
+  type        = bool
+  default     = true
+}
+
+variable "mariadb_group_consul_service_name" {
+  description = "The consul service name for the application."
+  type        = string
+  default     = "mariadb"
+}
+
+variable "mariadb_group_consul_service_port" {
+  description = "The consul service port for the application."
+  type        = string
+  default     = "3306"
+}
+
+variable "mariadb_group_consul_tags" {
+  description = ""
+  type = list(string)
+  default = [
+    "database"
+  ]
+}
+
+variable "mariadb_group_has_health_check" {
+  description = "If you want to register a health check in consul. Port needs to be exposed."
+  type        = bool
+  default     = false
+}
+
+variable "mariadb_group_health_check" {
+  description = ""
+  type = object({
+    port     = number
+    interval = string
+    timeout  = string
+  })
+
+  default = {
+    port     = 3306
+    interval = "10s"
+    timeout  = "2s"
+  }
+}
+
+variable "mariadb_group_restart_attempts" {
+  description = "The number of times the task should restart on updates"
+  type        = number
+  default     = 2
+}
+
+variable "mariadb_task_image" {
+  description = "MariaDB's Docker image."
+  type        = string
+  default     = "mariadb:10.6.4-focal"
+}
+
+variable "mariadb_task_volume_path" {
+  description = "The volume's absolute path in the host, as defined in Nomad's client configuration, to be used by MariaDB."
+  type        = string
+  default     = "/var/lib/mariadb"
+}
+
+variable "mariadb_task_env_vars" {
+  description = "MariaDB's environment variables."
+  type = list(object({
+    key   = string
+    value = string
+  }))
+  default = [
+    {
+      key   = "MYSQL_ROOT_PASSWORD"
+      value = "mariadb_root_password"
+    },
+    {
+      key   = "MYSQL_DATABASE"
+      value = "wordpress"
+    },
+    {
+      key   = "MYSQL_USER"
+      value = "wordpress"
+    },
+    {
+      key   = "MYSQL_PASSWORD"
+      value = "wordpress"
+    }
+  ]
+}
+
+variable "mariadb_task_resources" {
+  description = "The resources to assign to the MariaDB service."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 256,
+    memory = 256
+  }
+}
+
+// WordPress variables
+variable "wordpress_group_network" {
+  description = ""
+  type = list(object({
+    name = string
+    port = number
+  }))
+
+  default = [{
+    name = "http"
+    port = 80
+  }]
+}
+
+variable "wordpress_group_update" {
+  description = "The Wordpress update configuration options."
+  type        = object({
+    min_healthy_time  = string
+    healthy_deadline  = string
+    progress_deadline = string
+    auto_revert       = bool
+  })
+  default = {
+    min_healthy_time  = "10s",
+    healthy_deadline  = "5m",
+    progress_deadline = "10m",
+    auto_revert       = true,
+  }
+}
+
+variable "wordpress_group_register_consul_service" {
+  description = "If you want to register a consul service for the job."
+  type        = bool
+  default     = true
+}
+
+variable "wordpress_group_consul_service_name" {
+  description = "The consul service name for the application."
+  type        = string
+  default     = "wordpress"
+}
+
+variable "wordpress_group_consul_service_port" {
+  description = "The consul service port for the application."
+  type        = string
+  default     = "http"
+}
+
+variable "wordpress_group_consul_tags" {
+  description = ""
+  type = list(string)
+  default = [
+    "app"
+  ]
+}
+
+variable "wordpress_group_upstreams" {
+  description = "Consul Connect upstream configuration."
+  type = list(object({
+    name = string
+    port = number
+  }))
+  default = [{
+    name = "mariadb"
+    port = 3306
+  }]
+}
+
+variable "wordpress_group_has_health_check" {
+  description = "If you want to register a health check in consul"
+  type        = bool
+  default     = true
+}
+
+variable "wordpress_group_health_check" {
+  description = ""
+  type = object({
+    name     = string
+    path     = string
+    port     = string
+    interval = string
+    timeout  = string
+  })
+
+  default = {
+    name     = "wordpress"
+    path     = "/wp-admin/install.php"
+    port     = "http"
+    interval = "10s"
+    timeout  = "2s"
+  }
+}
+
+variable "wordpress_group_restart_attempts" {
+  description = "The number of times the task should restart on updates"
+  type        = number
+  default     = 2
+}
+
+variable "wordpress_task_image" {
+  description = "Wordpress Docker image."
+  type        = string
+  default     = "wordpress:5.8.1-apache"
+}
+
+variable "wordpress_task_env_vars" {
+  description = "Wordpress environment variables."
+  type = list(object({
+    key   = string
+    value = string
+  }))
+    default = [
+    {
+      key   = "WORDPRESS_DB_HOST"
+      value = "$${NOMAD_UPSTREAM_ADDR_mariadb}"
+    },
+    {
+      key   = "WORDPRESS_DB_USER"
+      value = "wordpress"
+    },
+    {
+      key   = "WORDPRESS_DB_PASSWORD"
+      value = "wordpress"
+    },
+    {
+      key   = "WORDPRESS_DB_NAME"
+      value = "wordpress"
+    }
+  ]
+}
+
+variable "wordpress_task_resources" {
+  description = "The resources to assign to the Wordpress service."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 256,
+    memory = 256
+  }
+}
+
+// phpMyAdmin variables
+variable "phpmyadmin_group_network" {
+  description = ""
+  type = list(object({
+    name = string
+    port = number
+  }))
+
+  default = [{
+    name = "http"
+    port = 80
+  }]
+}
+
+variable "phpmyadmin_group_update" {
+  description = "The phpmyadmin update configuration options."
+  type        = object({
+    min_healthy_time  = string
+    healthy_deadline  = string
+    progress_deadline = string
+    auto_revert       = bool
+  })
+  default = {
+    min_healthy_time  = "10s",
+    healthy_deadline  = "5m",
+    progress_deadline = "10m",
+    auto_revert       = true,
+  }
+}
+
+variable "phpmyadmin_group_register_consul_service" {
+  description = "If you want to register a consul service for the job."
+  type        = bool
+  default     = true
+}
+
+variable "phpmyadmin_group_consul_service_name" {
+  description = "The consul service name for the application."
+  type        = string
+  default     = "phpmyadmin"
+}
+
+variable "phpmyadmin_group_consul_service_port" {
+  description = "The consul service port for the application."
+  type        = string
+  default     = "http"
+}
+
+variable "phpmyadmin_group_consul_tags" {
+  description = ""
+  type = list(string)
+  default = [
+    "app"
+  ]
+}
+
+variable "phpmyadmin_group_upstreams" {
+  description = "Consul Connect upstream configuration."
+  type = list(object({
+    name = string
+    port = number
+  }))
+  default = [{
+    name = "mariadb"
+    port = 3306
+  }]
+}
+
+variable "phpmyadmin_group_has_health_check" {
+  description = "If you want to register a health check in consul."
+  type        = bool
+  default     = true
+}
+
+variable "phpmyadmin_group_health_check" {
+  description = ""
+  type = object({
+    name     = string
+    path     = string
+    port     = string
+    interval = string
+    timeout = string
+  })
+
+  default = {
+    name     = "phpmyadmin"
+    path     = "/"
+    port     = "http"
+    interval = "10s"
+    timeout  = "2s"
+  }
+}
+
+variable "phpmyadmin_group_restart_attempts" {
+  description = "The number of times the task should restart on updates."
+  type        = number
+  default     = 2
+}
+
+variable "phpmyadmin_task_image" {
+  description = "phpmyadmin Docker image."
+  type        = string
+  default     = "phpmyadmin:5.1.1-apache"
+}
+
+variable "phpmyadmin_task_env_vars" {
+  description = "phpmyadmin environment variables."
+  type = list(object({
+    key   = string
+    value = string
+  }))
+    default = [
+    {
+      key   = "MYSQL_ROOT_PASSWORD"
+      value = "mariadb_root_password"
+    },
+    {
+      key   = "PMA_HOST"
+      value = "$${NOMAD_UPSTREAM_IP_mariadb}"
+    },
+    {
+      key   = "PMA_PORT"
+      value = "$${NOMAD_UPSTREAM_PORT_mariadb}"
+    },
+    {
+      key   = "MYSQL_USERNAME"
+      value = "wordpress"
+    }
+  ]
+}
+
+variable "phpmyadmin_task_resources" {
+  description = "The resources to assign to the phpmyadmin service."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 128,
+    memory = 128
+  }
+}


### PR DESCRIPTION
Hello!

This pack contains a service job that runs [WordPress](https://wordpress.org/) in a single Nomad client. It currently supports
being run by the [Docker](https://www.nomadproject.io/docs/drivers/docker) driver.

It has 3 tasks:
- **WordPress:** [*(reference)*](https://wordpress.org/) the open-source CMS;
- **MariaDB:** [*(reference)*](https://mariadb.org/) the database used by Wordpress;
- **phpMyAdmin:** [*(reference)*](https://www.phpmyadmin.net/) to handle the administration of MariaDB over web.

Setup:
- Service-to-service communication is handled with Consul Connect (via sidecar proxies);
- MariaDB's state is persisted with Nomad Host Volumes;
- Consul service registration and service health checks are enabled by default for WordPress and phpMyAdmin. MariaDB only has service registration enabled.

Thank you

Relates to #13 