### PR TITLE
feat: Add caddy pack

### DIFF
--- a/packs/caddy/README.md
+++ b/packs/caddy/README.md
@@ -1,0 +1,18 @@
+# Caddy
+
+This pack contains a single system job that runs [Caddy](https://caddyserver.com/v2) across all Nomad clients.
+
+## Dependencies
+
+This pack requires Linux clients to run.
+
+## Variables
+
+- `job_name` (string) - The name to use as the job name which overrides using the pack name.
+- `datacenters` (list of string) - A list of datacenters in the region which are eligible for task placement.
+- `region` (string) - The region where the job should be placed.
+- `namespace` (string "default") - The namespace where the job should be placed.
+- `http_port` (number) - The Nomad client port that routes HTTP traffic to Caddy.
+- `https_port` (number) - The Nomad client port that routes HTTPS traffic to Caddy.
+- `version_tag` (string) - The docker image version. For options, see [Dockerhub](https://hub.docker.com/_/caddy).
+- `resources` (object) - The resource to assign to the Caddy system task that runs on every client.

--- a/packs/caddy/metadata.hcl
+++ b/packs/caddy/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url = "https://caddyserver.com/v2"
+  author = "github.com/mr-karan"
+}
+
+pack {
+  name = "caddy"
+  description = "Caddy 2 is a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go. This pack runs it as a Nomad system job for load balancing."
+  url = "https://github.com/hashicorp/nomad-pack-community-registry/caddy"
+  version = "0.0.1"
+}

--- a/packs/caddy/outputs.tpl
+++ b/packs/caddy/outputs.tpl
@@ -1,0 +1,4 @@
+Caddy successfully deployed.
+
+Visit the official documentation for configuring Caddy:
+https://caddyserver.com/docs/

--- a/packs/caddy/templates/_helpers.tpl
+++ b/packs/caddy/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+// allow nomad-pack to set the job name
+
+[[- define "job_name" -]]
+[[- if eq .caddy.job_name "" -]]
+[[- .nomad_pack.pack.name | quote -]]
+[[- else -]]
+[[- .caddy.job_name | quote -]]
+[[- end -]]
+[[- end -]]
+
+// only deploys to a region if specified
+
+[[- define "region" -]]
+[[- if not (eq .caddy.region "") -]]
+region = [[ .caddy.region | quote]]
+[[- end -]]
+[[- end -]]

--- a/packs/caddy/templates/caddy.nomad.tpl
+++ b/packs/caddy/templates/caddy.nomad.tpl
@@ -1,0 +1,85 @@
+job [[ template "job_name" . ]] {
+[[ template "region" . ]]
+datacenters = [ [[ range $idx, $dc := .caddy.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  namespace = [[ .caddy.namespace | quote ]]
+
+  type = "system"
+
+  // must have linux for network mode
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "caddy" {
+    count = 1
+
+    # Using ephemeral_disk to store Caddy data.
+    # The data directory must not be treated as a cache.
+    # Caddy stores TLS certificates, private keys, OCSP staples, and other necessary information to the data directory.
+    # The path to this directory is configured via `XDG_DATA_HOME` variable.
+    ephemeral_disk {
+      migrate = true
+      size    = 300
+      sticky  = true
+    }
+
+    network {
+      port "https" {
+        static = [[ .caddy.https_port ]]
+        to     = 443
+      }
+      port "http" {
+        static = [[ .caddy.http_port ]]
+        to     = 80
+      }
+    }
+
+    service {
+      name = "caddy-https"
+      port = "https"
+    }
+
+    service {
+      name = "caddy-http"
+      port = "http"
+    }
+
+    task "caddy" {
+      driver = "docker"
+
+      env {
+        XDG_DATA_HOME = "${NOMAD_ALLOC_DIR}/data/"
+      }
+
+      config {
+        image = "caddy:[[ .caddy.version_tag ]]"
+        ports = ["https", "http"]
+
+        # Bind the config file to container.
+        mount {
+          type   = "bind"
+          source = "configs"
+          target = "/etc/caddy"
+        }
+      }
+
+      [[- if ne .caddy.caddyfile "" ]]
+      template {
+        data        = <<EOH
+[[ .caddy.caddyfile ]]
+EOH
+        destination = "configs/Caddyfile"
+        # Caddy doesn't support reload via signals.
+        # https://github.com/caddyserver/caddy/issues/3967
+        change_mode = "restart"
+      }
+      [[- end ]]
+
+      resources {
+        cpu    = [[ .caddy.resources.cpu ]]
+        memory = [[ .caddy.resources.memory ]]
+      }
+    }
+  }
+}

--- a/packs/caddy/variables.hcl
+++ b/packs/caddy/variables.hcl
@@ -1,0 +1,93 @@
+variable "job_name" {
+  description = "The name to use as the job name which overrides using the pack name"
+  type        = string
+  // If "", the pack name will be used
+  default = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement"
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "region" {
+  description = "The region where the job should be placed"
+  type        = string
+  default     = "global"
+}
+
+variable "namespace" {
+  description = "The namespace where the job should be placed."
+  type        = string
+  default     = "default"
+}
+
+variable "consul_service_name" {
+  description = "The consul service you wish to load balance"
+  type        = string
+  default     = "webapp"
+}
+
+variable "version_tag" {
+  description = "The docker image version. For options, see https://hub.docker.com/_/caddy"
+  type        = string
+  default     = "2.4.5"
+}
+
+variable "http_port" {
+  description = "The Nomad client port that routes HTTP traffic to Caddy."
+  type        = number
+  default     = 8443
+}
+
+variable "https_port" {
+  description = "The Nomad client port that routes HTTPS traffic to Caddy."
+  type        = number
+  default     = 8080
+}
+
+variable "resources" {
+  description = "The resource to assign to the Caddy system task that runs on every client"
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 200,
+    memory = 256
+  }
+}
+
+variable "caddyfile" {
+  description = "The Caddyfile configuration to pass to the task."
+  type        = string
+  default     = <<EOF
+# The Caddyfile is an easy way to configure your Caddy web server.
+#
+# Unless the file starts with a global options block, the first
+# uncommented line is always the address of your site.
+#
+# To use your own domain name (with automatic HTTPS), first make
+# sure your domain's A/AAAA DNS records are properly pointed to
+# this machine's public IP, then replace ":80" below with your
+# domain name.
+
+:80 {
+	# Set this path to your site's directory.
+	root * /usr/share/caddy
+
+	# Enable the static file server.
+	file_server
+
+	# Another common task is to set up a reverse proxy:
+	# reverse_proxy localhost:8080
+
+	# Or serve a PHP site through php-fpm:
+	# php_fastcgi localhost:9000
+}
+
+# Refer to the Caddy docs for more information:
+# https://caddyserver.com/docs/caddyfile
+EOF
+}


### PR DESCRIPTION
Add a pack for deploying [Caddy](https://caddyserver.com/) as a on Nomad.

Some considerations:

- Since Caddy generates TLS certs, it preserves them to a data directory. I've used `ephemeral_disk` here with `migrate=true`. This would help Caddy migrate this data to a new allocation should this happen. However, since it's a system job, the chances of this allocation being scheduled to a new client is less and in that rare event, `caddy` can regenerate the TLS certs as well and persist for future. Considering all these factors, decided to use `ephemeral_disk` here. We can discuss if this needs to be changed.

- Added a variable `caddyfile` so the user can give their own config. The default is the one that ships in the official Docker image.