### PR TITLE
add InfluxDB pack

### DIFF
--- a/packs/influxdb/README.md
+++ b/packs/influxdb/README.md
@@ -12,10 +12,14 @@ This pack contains all you need to deploy InfluxDB (version 2 by default) in Nom
 - `constraints` (string) - Constraints to apply to the entire job.
 - `image_name` (string) - The docker image name.
 - `image_tag` (string) - The docker image tag.
-- `influxdb_task_resources` (object, number number) Resources used by InfluxDB task
+- `task_resources` (object, number number) Resources used by InfluxDB task
 - `register_consul_service` (bool) - If you want to register a consul service for the job
 - `consul_service_name` (string) - The consul service name for the hello-world application
 - `consul_service_tags` (list of string) - The consul service name for the hello-world application
+- `config_volume_name` (string) - The name of the configuration dedicated volume you want InfluxDB to use
+- `data_volume_name` (string) - The name of the data dedicated volume you want InfluxDB to use
+- `config_volume_type` (string) - The type of the configuration dedicated volume you want InfluxDB to use
+- `data_volume_type` (string) - The type of the data dedicated volume you want InfluxDB to use
 - `docker_influxdb_env_vars` (map of string) - Environment variables to pass to Docker container
 
 ## Automated Setup

--- a/packs/influxdb/README.md
+++ b/packs/influxdb/README.md
@@ -1,0 +1,24 @@
+# InfluxDB
+
+This pack contains all you need to deploy InfluxDB (version 2 by default) in Nomad. It uses Docker driver.
+
+
+## Variables
+
+- `job_name` (string) - The name to use as the job name which overrides using the pack name.
+- `region` (string) - The region where jobs will be deployed.
+- `datacenters` (list of strings) - A list of datacenters in the region which are eligible for task placement.
+- `namespace` (string) - The namespace where the job should be placed.
+- `constraints` (string) - Constraints to apply to the entire job.
+- `image_name` (string) - The docker image name.
+- `image_tag` (string) - The docker image tag.
+- `influxdb_task_resources` (object, number number) Resources used by InfluxDB task
+- `register_consul_service` (bool) - If you want to register a consul service for the job
+- `consul_service_name` (string) - The consul service name for the hello-world application
+- `consul_service_tags` (list of string) - The consul service name for the hello-world application
+- `docker_influxdb_env_vars` (map of string) - Environment variables to pass to Docker container
+
+## Automated Setup
+
+If you pass the right environment variables to the pack, you can automatically setup the init of InfluxDB.
+An example of the `docker_influxdb_env_vars` to use is in the `vars.nomad` file.

--- a/packs/influxdb/metadata.hcl
+++ b/packs/influxdb/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = "https://github.com/hashicorp/nomad-pack"
+  author = "HashiCorp"
+}
+
+pack {
+  name        = "influxdb"
+  description = "InfluxDB is an open source time series database for recording metrics, events, and analytics."
+  url         = "https://github.com/hashicorp/nomad-pack-community-registry/influxdb"
+  version     = "0.0.1"
+}

--- a/packs/influxdb/metadata.hcl
+++ b/packs/influxdb/metadata.hcl
@@ -1,6 +1,6 @@
 app {
-  url    = "https://github.com/hashicorp/nomad-pack"
-  author = "HashiCorp"
+  url    = "https://www.influxdata.com/"
+  author = "InfluxDB"
 }
 
 pack {

--- a/packs/influxdb/outputs.tpl
+++ b/packs/influxdb/outputs.tpl
@@ -1,0 +1,1 @@
+Congrats on deploying [[ .nomad_pack.pack.name ]].

--- a/packs/influxdb/templates/_helpers.tpl
+++ b/packs/influxdb/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+// allow nomad-pack to set the job name
+
+[[- define "job_name" -]]
+[[- if eq .influxdb.job_name "" -]]
+[[- .nomad_pack.pack.name | quote -]]
+[[- else -]]
+[[- .influxdb.job_name | quote -]]
+[[- end -]]
+[[- end -]]
+
+// only deploys to a region if specified
+
+[[- define "region" -]]
+[[- if not (eq .influxdb.region "") -]]
+region = [[ .influxdb.region | quote]]
+[[- end -]]
+[[- end -]]

--- a/packs/influxdb/templates/influxdb.nomad.tpl
+++ b/packs/influxdb/templates/influxdb.nomad.tpl
@@ -74,6 +74,7 @@ job [[ template "job_name" . ]] {
     task "chown" {
         lifecycle {
             hook = "prestart"
+            sidecar = false
         }
 
         volume_mount {
@@ -82,11 +83,16 @@ job [[ template "job_name" . ]] {
           read_only   = false
         }
 
-        driver = "exec"
-        user = "root"
+        driver = "docker"
         config = {
-            command = "chown"
-            args = ["-R", "1000:1000", "/var/lib/influxdb2"]
+          image   = "busybox:stable"
+          command = "sh"
+          args    = ["-c", "chown -R 1000:1000 /var/lib/influxdb2"]
+        }
+
+        resources {
+          cpu    = 200
+          memory = 128
         }
     }
     [[- end]]
@@ -95,6 +101,7 @@ job [[ template "job_name" . ]] {
     task "chown" {
         lifecycle {
             hook = "prestart"
+            sidecar = false
         }
 
         volume_mount {
@@ -103,11 +110,17 @@ job [[ template "job_name" . ]] {
           read_only   = false
         }
 
-        driver = "exec"
+        driver = "docker"
         user = "root"
         config = {
-            command = "chown"
-            args = ["-R", "1000:1000", "/etc/influxdb2"]
+            image   = "busybox:stable"
+            command = "sh"
+            args    = ["-c", "chown -R 1000:1000 /etc/influxdb2"]
+        }
+
+        resources {
+            cpu    = 200
+            memory = 128
         }
     }
     [[- end]]

--- a/packs/influxdb/templates/influxdb.nomad.tpl
+++ b/packs/influxdb/templates/influxdb.nomad.tpl
@@ -84,7 +84,7 @@ job [[ template "job_name" . ]] {
         }
 
         driver = "docker"
-        config = {
+        config {
           image   = "busybox:stable"
           command = "sh"
           args    = ["-c", "chown -R 1000:1000 /var/lib/influxdb2"]
@@ -112,7 +112,7 @@ job [[ template "job_name" . ]] {
 
         driver = "docker"
         user = "root"
-        config = {
+        config {
             image   = "busybox:stable"
             command = "sh"
             args    = ["-c", "chown -R 1000:1000 /etc/influxdb2"]

--- a/packs/influxdb/templates/influxdb.nomad.tpl
+++ b/packs/influxdb/templates/influxdb.nomad.tpl
@@ -1,0 +1,77 @@
+job [[ template "job_name" . ]] {
+  [[ template "region" . ]]
+  datacenters = [ [[ range $idx, $dc := .influxdb.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  type = "service"
+  [[ if .influxdb.namespace ]]
+  namespace   = [[ .influxdb.namespace | quote ]]
+  [[end]]
+  [[ if .influxdb.constraints ]][[ range $idx, $constraint := .influxdb.constraints ]]
+  constraint {
+    [[- if ne $constraint.attribute "" ]]
+    attribute = [[ $constraint.attribute | quote ]]
+    [[- end ]]
+    [[- if ne $constraint.value "" ]]
+    value     = [[ $constraint.value | quote ]]
+    [[- end ]]
+    [[- if ne $constraint.operator "" ]]
+    operator  = [[ $constraint.operator | quote ]]
+    [[- end ]]
+  }
+  [[- end ]]
+  [[- end ]]
+
+  group [[ template "job_name" . ]] {
+    count = 1
+
+    network {
+      port "http" {
+        to = 8086
+      }
+    }
+
+    [[ if .influxdb.register_consul_service ]]
+    service {
+      name = "[[ .influxdb.consul_service_name ]]"
+      [[if ne (len .influxdb.consul_service_tags) 0 ]]
+      tags = [ [[ range $idx, $tag := .influxdb.consul_service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+      [[ end ]]
+      port = "http"
+
+      check {
+        name     = "alive"
+        type     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+    [[ end ]]
+
+    restart {
+      attempts = 2
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task [[ template "job_name" . ]] {
+      driver = "docker"
+
+      config {
+        image = "[[ .influxdb.image_name ]]:[[ .influxdb.image_tag ]]"
+        ports = ["http"]
+      }
+      [[if ne (len .influxdb.docker_influxdb_env_vars) 0 ]]
+      env {
+        [[ range $key, $var := .influxdb.docker_influxdb_env_vars ]]
+        [[if ne (len $var) 0 ]][[ $key | upper ]] = [[ $var | quote ]][[ end ]]
+        [[ end ]]
+      }
+      [[ end ]]
+      resources {
+        cpu    = [[ .influxdb.influxdb_task_resources.cpu ]]
+        memory = [[ .influxdb.influxdb_task_resources.memory ]]
+      }
+    }
+  }
+}

--- a/packs/influxdb/templates/influxdb.nomad.tpl
+++ b/packs/influxdb/templates/influxdb.nomad.tpl
@@ -40,7 +40,7 @@ job [[ template "job_name" . ]] {
       check {
         name     = "alive"
         type     = "http"
-        path     = "/"
+        path     = "/health"
         interval = "10s"
         timeout  = "2s"
       }

--- a/packs/influxdb/templates/influxdb.nomad.tpl
+++ b/packs/influxdb/templates/influxdb.nomad.tpl
@@ -1,11 +1,11 @@
 job [[ template "job_name" . ]] {
   [[ template "region" . ]]
-  datacenters = [ [[ range $idx, $dc := .influxdb.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .influxdb.datacenters | toPrettyJson ]]
   type = "service"
-  [[ if .influxdb.namespace ]]
+  [[- if .influxdb.namespace ]]
   namespace   = [[ .influxdb.namespace | quote ]]
-  [[end]]
-  [[ if .influxdb.constraints ]][[ range $idx, $constraint := .influxdb.constraints ]]
+  [[- end]]
+  [[- if .influxdb.constraints ]][[ range $idx, $constraint := .influxdb.constraints ]]
   constraint {
     [[- if ne $constraint.attribute "" ]]
     attribute = [[ $constraint.attribute | quote ]]
@@ -29,7 +29,7 @@ job [[ template "job_name" . ]] {
       }
     }
 
-    [[ if .influxdb.register_consul_service ]]
+    [[- if .influxdb.register_consul_service ]]
     service {
       name = "[[ .influxdb.consul_service_name ]]"
       [[if ne (len .influxdb.consul_service_tags) 0 ]]
@@ -45,23 +45,23 @@ job [[ template "job_name" . ]] {
         timeout  = "2s"
       }
     }
-    [[ end ]]
+    [[- end ]]
 
-    [[ if .influxdb.config_volume_name ]]
+    [[- if .influxdb.config_volume_name ]]
     volume "[[.influxdb.config_volume_name]]" {
       type      = "[[.influxdb.config_volume_type]]"
       read_only = false
       source    = "[[.influxdb.config_volume_name]]"
     }
-    [[end]]
+    [[- end]]
 
-    [[ if .influxdb.data_volume_name ]]
+    [[- if .influxdb.data_volume_name ]]
     volume "[[.influxdb.data_volume_name]]" {
       type      = "[[.influxdb.data_volume_type]]"
       read_only = false
       source    = "[[.influxdb.data_volume_name]]"
     }
-    [[end]]
+    [[- end]]
 
     restart {
       attempts = 2
@@ -70,7 +70,7 @@ job [[ template "job_name" . ]] {
       mode = "fail"
     }
 
-    [[ if .influxdb.data_volume_name ]]
+    [[- if .influxdb.data_volume_name ]]
     task "chown" {
         lifecycle {
             hook = "prestart"
@@ -89,9 +89,9 @@ job [[ template "job_name" . ]] {
             args = ["-R", "1000:1000", "/var/lib/influxdb2"]
         }
     }
-    [[end]]
+    [[- end]]
 
-    [[ if .influxdb.config_volume_name ]]
+    [[- if .influxdb.config_volume_name ]]
     task "chown" {
         lifecycle {
             hook = "prestart"
@@ -110,38 +110,38 @@ job [[ template "job_name" . ]] {
             args = ["-R", "1000:1000", "/etc/influxdb2"]
         }
     }
-    [[end]]
+    [[- end]]
 
     task [[ template "job_name" . ]] {
       driver = "docker"
 
-      [[ if .influxdb.data_volume_name ]]
+      [[- if .influxdb.data_volume_name ]]
       volume_mount {
         volume      = "[[ .influxdb.data_volume_name ]]"
         destination = "/var/lib/influxdb2"
         read_only   = false
       }
-      [[end]]
+      [[- end]]
 
-      [[ if .influxdb.config_volume_name ]]
+      [[- if .influxdb.config_volume_name ]]
       volume_mount {
         volume      = "[[ .influxdb.config_volume_name ]]"
         destination = "/etc/influxdb2"
         read_only   = false
       }
-      [[end]]
+      [[- end]]
 
       config {
         image = "[[ .influxdb.image_name ]]:[[ .influxdb.image_tag ]]"
         ports = ["http"]
       }
-      [[if ne (len .influxdb.docker_influxdb_env_vars) 0 ]]
+      [[- if ne (len .influxdb.docker_influxdb_env_vars) 0 ]]
       env {
         [[ range $key, $var := .influxdb.docker_influxdb_env_vars ]]
         [[if ne (len $var) 0 ]][[ $key | upper ]] = [[ $var | quote ]][[ end ]]
         [[ end ]]
       }
-      [[ end ]]
+      [[- end ]]
       resources {
         cpu    = [[ .influxdb.task_resources.cpu ]]
         memory = [[ .influxdb.task_resources.memory ]]

--- a/packs/influxdb/templates/influxdb.nomad.tpl
+++ b/packs/influxdb/templates/influxdb.nomad.tpl
@@ -71,7 +71,7 @@ job [[ template "job_name" . ]] {
     }
 
     [[- if .influxdb.data_volume_name ]]
-    task "chown" {
+    task "chown_data_volume" {
         lifecycle {
             hook = "prestart"
             sidecar = false
@@ -98,7 +98,7 @@ job [[ template "job_name" . ]] {
     [[- end]]
 
     [[- if .influxdb.config_volume_name ]]
-    task "chown" {
+    task "chown_config_volume" {
         lifecycle {
             hook = "prestart"
             sidecar = false

--- a/packs/influxdb/variables.hcl
+++ b/packs/influxdb/variables.hcl
@@ -50,7 +50,7 @@ variable "image_tag" {
   default     = "2.0.9"
 }
 
-variable "influxdb_task_resources" {
+variable "task_resources" {
   description = "Resources used by InfluxDB task."
   type = object({
     cpu    = number
@@ -78,6 +78,28 @@ variable "consul_service_tags" {
   description = "The consul service name for the application."
   type        = list(string)
   default     = []
+}
+
+variable "data_volume_name" {
+  description = "The name of the dedicated data volume you want InfluxDB to use."
+  type        = string
+}
+
+variable "data_volume_type" {
+  description = "The type of the dedicated data volume you want InfluxDB to use."
+  type        = string
+  default     = "host"
+}
+
+variable "config_volume_name" {
+  description = "The name of the dedicated config volume you want InfluxDB to use."
+  type        = string
+}
+
+variable "config_volume_type" {
+  description = "The type of the dedicated config volume you want InfluxDB to use."
+  type        = string
+  default     = "host"
 }
 
 variable "docker_influxdb_env_vars" {

--- a/packs/influxdb/variables.hcl
+++ b/packs/influxdb/variables.hcl
@@ -1,0 +1,89 @@
+variable "job_name" {
+  description = "The name to use as the job name which overrides using the pack name."
+  type        = string
+  // If "", the pack name will be used
+  default = "influxdb"
+}
+
+variable "region" {
+  description = "The region where jobs will be deployed."
+  type        = string
+  default     = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement."
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "namespace" {
+  description = "The namespace where the job should be placed."
+  type        = string
+}
+
+variable "constraints" {
+  description = "Constraints to apply to the entire job."
+  type = list(object({
+    attribute = string
+    operator  = string
+    value     = string
+  }))
+  default = [
+    {
+      attribute = "$${attr.kernel.name}",
+      value     = "(linux|darwin)",
+      operator  = "regexp",
+    },
+  ]
+}
+
+variable "image_name" {
+  description = "The docker image name."
+  type        = string
+  default     = "influxdb"
+}
+
+variable "image_tag" {
+  description = "The docker image tag."
+  type        = string
+  default     = "2.0.9"
+}
+
+variable "influxdb_task_resources" {
+  description = "Resources used by InfluxDB task."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 500,
+    memory = 256,
+  }
+}
+
+variable "register_consul_service" {
+  description = "If you want to register a consul service for the job."
+  type        = bool
+  default     = false
+}
+
+variable "consul_service_name" {
+  description = "The consul service name for the application."
+  type        = string
+  default     = "influxdb"
+}
+
+variable "consul_service_tags" {
+  description = "The consul service name for the application."
+  type        = list(string)
+  default     = []
+}
+
+variable "docker_influxdb_env_vars" {
+  type        = map(string)
+  description = "Environment variables to pass to Docker container."
+  default     = {}
+}
+
+

--- a/packs/influxdb/vars.nomad
+++ b/packs/influxdb/vars.nomad
@@ -7,4 +7,6 @@ docker_influxdb_env_vars = {
   "docker_influxdb_init_org" : "my-org",
   "docker_influxdb_init_bucket" : "my-bucket",
 }
+config_volume_name = "config_volume"
+data_volume_name = "data_volume"
 register_consul_service = true

--- a/packs/influxdb/vars.nomad
+++ b/packs/influxdb/vars.nomad
@@ -1,0 +1,10 @@
+docker_influxdb_env_vars = {
+  "docker_influxdb_init_mode" : "setup",
+  "docker_influxdb_init_retention" : "1w",
+  "docker_influxdb_init_admin_token" : "my-super-secret-auth-token",
+  "docker_influxdb_init_username" : "my-user",
+  "docker_influxdb_init_password" : "my-password",
+  "docker_influxdb_init_org" : "my-org",
+  "docker_influxdb_init_bucket" : "my-bucket",
+}
+register_consul_service = true


### PR DESCRIPTION
This is a PR that adds InfluxDB pack. The Nomad driver used is Docker and it allows you to pass env vars to the container to make an automated init setup of the DB. Plus, you can customize the job.