### PR TITLE
Pack: Outline

### DIFF
--- a/packs/outline/README.md
+++ b/packs/outline/README.md
@@ -1,0 +1,273 @@
+# Outline
+
+This pack contains a service job that runs [Outline](https://www.getoutline.com/) in a single Nomad client. It currently supports
+being run by the [Docker](https://www.nomadproject.io/docs/drivers/docker) driver.
+
+It has 4 tasks:
+- **Outline:** [*(reference)*](https://www.getoutline.com/) the wiki and knowledgebase for teams;
+- **PostgreSQL:** [*(reference)*](https://www.postgresql.org/) the persistent database used by Outline;
+- **Redis:** [*(reference)*](https://redis.io/) for in-memory storage and cache;
+- **MinIO:** [*(reference)*](https://min.io/) for images storage, compatible with S3 cloud storage service.
+
+Setup:
+- Service-to-service communication is handled with Consul Connect;
+- Bitnami images are being used for [PostgreSQL](https://hub.docker.com/r/bitnami/postgresql), [Redis](https://hub.docker.com/r/bitnami/redis) and [MinIO](https://hub.docker.com/r/bitnami/minio). They are non-root containers and as such the mounted files and directories must have the proper permissions for the UID 1001. To achieve this, these 3 images are being run as user 1001 and there are prestart tasks that create their respective directories, while setting the correct ownership, in the host filesystem with the raw exec driver;
+- Only MinIO and Outline ports are exposed. To simplify the pack, MinIO has a static host port of 9000, whereas Outline's port is being randomly assigned. In production it's recommended that none of the services are directly exposed and that traffic is run through a reverse proxy that supports Consul Connect enabled services, like Traefik;
+- MinIO's group has a poststart task that applies a policy that disables directory browsing. It does it by finding the correct Docker container, exec'ing into the container and applying the policy with MinIO's MC;
+- Outline supports a number of authentication methods. Slack is used for demonstration purposes, but enabling more authentication methods is a matter of defining the [environment variables](https://github.com/outline/outline/blob/main/.env.sample);
+- The default variables are defined for a local setup.
+
+## Requirements
+Clients that expect to run this job require:
+- [Docker volumes](https://www.nomadproject.io/docs/drivers/docker "Docker volumes") to be enabled within their Docker plugin stanza:
+```hcl
+plugin "docker" {
+  config {
+    volumes {
+      enabled = true
+    }
+  }
+}
+```
+
+- [Raw Exec](https://www.nomadproject.io/docs/drivers/raw_exec "Raw Exec") driver to be enabled:
+```hcl
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+```
+
+- [CNI plugins installed](https://www.nomadproject.io/docs/job-specification/network#network-modes "CNI plugins installed") and [its path](https://www.nomadproject.io/docs/configuration/client#cni_path "its path") set in the client's configuration if network mode is set to bridge.
+
+- [Consul Connect](https://www.nomadproject.io/docs/integrations/consul-connect "Consul Connect") to be enabled in Consul's configuration:
+```hcl
+ports {
+  grpc = 8502
+}
+
+connect {
+  enabled = true
+}
+```
+
+## Customizing the Docker images
+
+The 4 docker images can be replaced by using their variable names:
+- postgresql_task_image
+- minio_task_image
+- redis_task_image
+- outline_task_image
+
+Example:
+```
+nomad-pack run outline --var outline_task_image="outlinewiki/outline:0.59.0"
+```
+
+## Customizing the environment variables
+
+The 4 tasks have default environment variables. However, it's recommended to change the ones related to authentication if the services are going to be publicly accessible. Additional environment variables can be passed to nomad-pack, even if not in the default variables file.
+
+Default PostgreSQL environment variables:
+```
+postgresql_task_env_vars = [
+  {
+    key = "ALLOW_EMPTY_PASSWORD"
+    value = "no"
+  },
+  {
+    key = "POSTGRESQL_USERNAME"
+    value = "outline_user"
+  },
+  {
+    key = "POSTGRESQL_PASSWORD"
+    value = "outline_user_password"
+  },
+  {
+    key = "POSTGRESQL_DATABASE"
+    value = "outline"
+  }
+]
+```
+
+Default Redis environment variables:
+```
+redis_task_env_vars = [
+  {
+    key = "ALLOW_EMPTY_PASSWORD"
+    value = "no"
+  },
+  {
+    key = "REDIS_PASSWORD"
+    value = "redis_password"
+  }
+]
+```
+
+Default MinIO environment variables:
+```
+minio_task_env_vars = [
+  {
+    key = "MINIO_ROOT_USER"
+    value = "minio_root_user"
+  },
+  {
+    key = "MINIO_ROOT_PASSWORD"
+    value = "minio_root_password"
+  },
+  {
+    key = "MINIO_BROWSER"
+    value = "off"
+  },
+  {
+    key = "MINIO_DEFAULT_BUCKETS"
+    value = "outline:none"
+  },
+  {
+    key = "MINIO_FORCE_NEW_KEYS"
+    value = "yes"
+  }
+]
+```
+
+Default Outline environment variables:
+```
+outline_task_env_vars = [
+  {
+    key = "SECRET_KEY"
+    value = "d1434eff0725153e1cc457a013b53dbcdba6a2b40f00729be5680b56fc003897"
+  },
+  {
+    key = "UTILS_SECRET"
+    value = "d5c59234b0018fe6036b0376d022c7f5187feb8cc1769c7bc4c282ed8a983b54"
+  },
+  {
+    key = "REDIS_URL"
+    value = "redis://:redis_password@$${NOMAD_UPSTREAM_ADDR_outline-redis}"
+  },
+  {
+    key = "DATABASE_URL"
+    value = "postgres://outline_user:outline_user_password@$${NOMAD_UPSTREAM_ADDR_outline-postgresql}/outline"
+  },
+  {
+    key = "DATABASE_URL_TEST"
+    value = "postgres://outline_user:outline_user_password@$${NOMAD_UPSTREAM_ADDR_outline-postgresql}/outline_test"
+  },
+  {
+    key = "PGSSLMODE"
+    value = "disable"
+  },
+  {
+    key = "URL"
+    value = "http://localhost:3000"
+  },
+  {
+    key = "PORT"
+    value = "3000"
+  },
+  {
+    key = "AWS_ACCESS_KEY_ID"
+    value = "minio_root_user"
+  },
+  {
+    key = "AWS_SECRET_ACCESS_KEY"
+    value = "minio_root_password"
+  },
+  {
+    key = "AWS_REGION"
+    value = "us-east-1"
+  },
+  {
+    key = "AWS_S3_UPLOAD_BUCKET_URL"
+    value = "http://localhost:9000"
+  },
+  {
+    key = "AWS_S3_UPLOAD_BUCKET_NAME"
+    value = "outline"
+  },
+  {
+    key = "AWS_S3_UPLOAD_MAX_SIZE"
+    value = "26214400"
+  },
+  {
+    key = "AWS_S3_FORCE_PATH_STYLE"
+    value = "true"
+  },
+  {
+    key = "AWS_S3_ACL"
+    value = "private"
+  },
+  {
+    key = "SLACK_KEY"
+    value = "123123"
+  },
+  {
+    key = "SLACK_SECRET"
+    value = "123123"
+  },
+  {
+    key = "FORCE_HTTPS"
+    value = "false"
+  },
+  {
+    key = "ENABLE_UPDATES"
+    value = "no"
+  },
+  {
+    key = "WEB_CONCURRENCY"
+    value = "1"
+  },
+  {
+    key = "MAXIMUM_IMPORT_SIZE"
+    value = "5120000"
+  },
+  {
+    key = "DEBUG"
+    value = "http"
+  },
+  {
+    key = "DEFAULT_LANGUAGE"
+    value = "en_US"
+  }
+]
+```
+
+## Customizing ports
+
+PostgreSQL and Redis ports are not exposed and communication to it needs to be done via its sidecar proxy.
+
+Outline's ports is exposed and randomly assigned to the host.
+
+MinIO port is exposed to the host and static.
+
+The usage of a reverse proxy, such as Traefik, is highly recommended.
+
+## Customizing resources
+
+The application resource limits can be customized on a task level. The variables names are:
+- outline_task_resources
+- postgresql_task_resources
+- redis_task_resources
+- minio_task_resources
+
+Example:
+```
+outline_task_resources = {
+  cpu = 1024
+  memory = 2048
+}
+```
+
+## Setting the host paths
+
+PostgreSQL, Redis and MinIO are using bind mounts for storage persistence.
+The path for the mounts can be replaced through the following variables:
+- postgresql_task_volume_path
+- redis_task_volume_path
+- minio_task_volume_path
+
+Example:
+```
+nomad-pack run outline --var postgresql_task_volume_path="/var/lib/outline/postgresql"
+```

--- a/packs/outline/metadata.hcl
+++ b/packs/outline/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = "https://www.getoutline.com/"
+  author = "General Outline, Inc. and contributors"
+}
+
+pack {
+  name        = "outline"
+  description = "Outline - Wiki and knowledgebase for teams"
+  url         = "https://github.com/hashicorp/nomad-pack-community-registry/outline"
+  version     = "0.0.1"
+}

--- a/packs/outline/templates/_helpers.tpl
+++ b/packs/outline/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+// allow nomad-pack to set the job name
+
+[[- define "job_name" -]]
+[[- if eq .outline.job_name "" -]]
+[[- .nomad_pack.pack.name | quote -]]
+[[- else -]]
+[[- .outline.job_name | quote -]]
+[[- end -]]
+[[- end -]]
+
+// only deploys to a region if specified
+
+[[- define "region" -]]
+[[- if not (eq .outline.region "") -]]
+region = [[ .outline.region | quote]]
+[[- end -]]
+[[- end -]]

--- a/packs/outline/templates/outline.nomad.tpl
+++ b/packs/outline/templates/outline.nomad.tpl
@@ -3,6 +3,16 @@ job [[ template "job_name" . ]] {
   datacenters = [ [[ range $idx, $dc := .outline.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
   type = "service"
 
+  [[ if .outline.constraints ]][[ range $idx, $constraint := .outline.constraints ]]
+  constraint {
+    attribute = [[ $constraint.attribute | quote ]]
+    value     = [[ $constraint.value | quote ]]
+    [[- if ne $constraint.operator "" ]]
+    operator  = [[ $constraint.operator | quote ]]
+    [[- end ]]
+  }
+  [[- end ]][[- end ]]
+
   group "outline-postgresql" {
     count = 1
 

--- a/packs/outline/templates/outline.nomad.tpl
+++ b/packs/outline/templates/outline.nomad.tpl
@@ -1,0 +1,363 @@
+job [[ template "job_name" . ]] {
+  [[ template "region" . ]]
+  datacenters = [ [[ range $idx, $dc := .outline.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  type = "service"
+
+  group "outline-postgresql" {
+    count = 1
+
+    network {
+      mode = "bridge"
+    }
+
+    update {
+      min_healthy_time  = [[ .outline.postgresql_group_update.min_healthy_time | quote ]]
+      healthy_deadline  = [[ .outline.postgresql_group_update.healthy_deadline | quote ]]
+      progress_deadline = [[ .outline.postgresql_group_update.progress_deadline | quote ]]
+      auto_revert       = [[ .outline.postgresql_group_update.auto_revert ]]
+    }
+
+    service {
+      name = [[ .outline.postgresql_group_consul_service_name | quote ]]
+      port = [[ .outline.postgresql_group_consul_service_port | quote ]]
+      tags = [ [[ range $idx, $tag := .outline.postgresql_group_consul_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+
+      connect {
+        sidecar_service {}
+      }
+    }
+
+    restart {
+      attempts = [[ .outline.postgresql_group_restart_attempts ]]
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "outline-postgresql" {
+      driver = "docker"
+      user = 1001
+
+      config {
+        image = [[.outline.postgresql_task_image | quote]]
+        volumes = [
+          "[[.outline.postgresql_task_volume_path]]:/bitnami/postgresql",
+        ]
+      }
+
+      [[- $postgresql_task_env_vars_length := len .outline.postgresql_task_env_vars ]]
+      [[- if not (eq $postgresql_task_env_vars_length 0) ]]
+      env {
+        [[- range $var := .outline.postgresql_task_env_vars ]]
+        [[ $var.key ]] = [[ $var.value | quote ]]
+        [[- end ]]
+      }
+      [[- end ]]
+
+      resources {
+        cpu    = [[ .outline.postgresql_task_resources.cpu ]]
+        memory = [[ .outline.postgresql_task_resources.memory ]]
+      }
+    }
+
+    task "create-postgresql-data-folder" {
+      lifecycle {
+        hook = "prestart"
+        sidecar = false
+      }
+
+      driver = "raw_exec"
+      
+      config {
+        command = "sh"
+        args = ["-c", "mkdir -p [[.outline.postgresql_task_volume_path]] && chown 1001:1001 [[.outline.postgresql_task_volume_path]]"]
+      }
+
+      resources {
+        cpu    = [[ .outline.postgresql_data_folder_task_resources.cpu ]]
+        memory = [[ .outline.postgresql_data_folder_task_resources.memory ]]
+      }
+    }
+  }
+
+  group "outline-minio" {
+    count = 1
+
+    network {
+      mode = "bridge"
+      [[- range $port := .outline.minio_group_network ]]
+      port [[ $port.name | quote ]] {
+        to = [[ $port.port ]]
+        static = [[ $port.port ]]
+      }
+      [[- end ]]
+    }
+
+    update {
+      min_healthy_time  = [[ .outline.minio_group_update.min_healthy_time | quote ]]
+      healthy_deadline  = [[ .outline.minio_group_update.healthy_deadline | quote ]]
+      progress_deadline = [[ .outline.minio_group_update.progress_deadline | quote ]]
+      auto_revert       = [[ .outline.minio_group_update.auto_revert ]]
+    }
+
+    service {
+      name = [[ .outline.minio_group_consul_service_name | quote ]]
+      port = [[ .outline.minio_group_consul_service_port | quote ]]
+      tags = [ [[ range $idx, $tag := .outline.minio_group_consul_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+
+      connect {
+        sidecar_service {}
+      }
+
+      check {
+        name = "outline-minio"
+        type = "http"
+        path = "/minio/health/live"
+        interval = "10s"
+        timeout = "2s"
+      }
+    }
+
+    restart {
+      attempts = [[ .outline.minio_group_restart_attempts ]]
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "outline-minio" {
+      driver = "docker"
+      user = 1001
+
+      config {
+        image = [[.outline.minio_task_image | quote]]
+        volumes = [
+          "[[.outline.minio_task_volume_path]]:/data",
+        ]
+      }
+
+      [[- $minio_task_env_vars_length := len .outline.minio_task_env_vars ]]
+      [[- if not (eq $minio_task_env_vars_length 0) ]]
+      env {
+        [[- range $var := .outline.minio_task_env_vars ]]
+        [[ $var.key ]] = [[ $var.value | quote ]]
+        [[- end ]]
+      }
+      [[- end ]]
+
+      resources {
+        cpu    = [[ .outline.minio_task_resources.cpu ]]
+        memory = [[ .outline.minio_task_resources.memory ]]
+      }
+
+      template {
+        data = <<EOF
+          {
+            "Version": "2012-10-17",
+            "Statement": [{
+              "Action": [
+                "s3:GetObject"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": [
+                  "*"
+                ]
+              },
+              "Resource": [
+                "arn:aws:s3:::outline/*"
+              ],
+              "Sid": ""
+            }]
+          }
+        EOF
+        destination = "/local/minio_policy.json"
+      }
+    }
+
+    task "create-minio-data-folder" {
+      lifecycle {
+        hook = "prestart"
+        sidecar = false
+      }
+
+      driver = "raw_exec"
+      
+      config {
+        command = "sh"
+        args = ["-c", "mkdir -p [[.outline.minio_task_volume_path]] && chown 1001:1001 [[.outline.minio_task_volume_path]]"]
+      }
+
+      resources {
+        cpu    = [[ .outline.minio_data_folder_task_resources.cpu ]]
+        memory = [[ .outline.minio_data_folder_task_resources.memory ]]
+      }
+    }
+
+    task "minio-apply-policy" {
+      lifecycle {
+        hook = "poststart"
+        sidecar = false
+      }
+
+      driver = "raw_exec"
+      
+      config {
+        command = "sh"
+        args = ["-c", "sleep 60s && docker exec $(docker ps -aqf 'name=^outline-minio') mc policy set-json /local/minio_policy.json local/outline"]
+      }
+
+      resources {
+        cpu    = [[ .outline.minio_apply_policy_task_resources.cpu ]]
+        memory = [[ .outline.minio_apply_policy_task_resources.memory ]]
+      }
+    }
+  }
+
+  group "outline-redis" {
+    count = 1
+
+    network {
+      mode = "bridge"
+    }
+
+    update {
+      min_healthy_time  = [[ .outline.redis_group_update.min_healthy_time | quote ]]
+      healthy_deadline  = [[ .outline.redis_group_update.healthy_deadline | quote ]]
+      progress_deadline = [[ .outline.redis_group_update.progress_deadline | quote ]]
+      auto_revert       = [[ .outline.redis_group_update.auto_revert ]]
+    }
+
+    service {
+      name = [[ .outline.redis_group_consul_service_name | quote ]]
+      port = [[ .outline.redis_group_consul_service_port | quote ]]
+      tags = [ [[ range $idx, $tag := .outline.redis_group_consul_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+
+      connect {
+        sidecar_service {}
+      }
+    }
+
+    restart {
+      attempts = [[ .outline.redis_group_restart_attempts ]]
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "outline-redis" {
+      driver = "docker"
+      user = 1001
+
+      config {
+        image = [[.outline.redis_task_image | quote]]
+        volumes = [
+          "[[.outline.redis_task_volume_path]]:/bitnami/redis/data",
+        ]
+      }
+
+      [[- $redis_task_env_vars_length := len .outline.redis_task_env_vars ]]
+      [[- if not (eq $redis_task_env_vars_length 0) ]]
+      env {
+        [[- range $var := .outline.redis_task_env_vars ]]
+        [[ $var.key ]] = [[ $var.value | quote ]]
+        [[- end ]]
+      }
+      [[- end ]]
+
+      resources {
+        cpu    = [[ .outline.redis_task_resources.cpu ]]
+        memory = [[ .outline.redis_task_resources.memory ]]
+      }
+    }
+
+    task "create-redis-data-folder" {
+      lifecycle {
+        hook = "prestart"
+        sidecar = false
+      }
+
+      driver = "raw_exec"
+      
+      config {
+        command = "sh"
+        args = ["-c", "mkdir -p [[.outline.redis_task_volume_path]] && chown 1001:1001 [[.outline.redis_task_volume_path]]"]
+      }
+
+      resources {
+        cpu    = [[ .outline.redis_data_folder_task_resources.cpu ]]
+        memory = [[ .outline.redis_data_folder_task_resources.memory ]]
+      }
+    }
+  }
+
+  group "outline" {
+    count = 1
+
+    network {
+      mode = "bridge"
+      [[- range $port := .outline.outline_group_network ]]
+      port [[ $port.name | quote ]] {
+        to = [[ $port.port ]]
+      }
+      [[- end ]]
+    }
+
+    update {
+      min_healthy_time  = [[ .outline.outline_group_update.min_healthy_time | quote ]]
+      healthy_deadline  = [[ .outline.outline_group_update.healthy_deadline | quote ]]
+      progress_deadline = [[ .outline.outline_group_update.progress_deadline | quote ]]
+      auto_revert       = [[ .outline.outline_group_update.auto_revert ]]
+    }
+
+    service {
+      name = [[ .outline.outline_group_consul_service_name | quote ]]
+      port = [[ .outline.outline_group_consul_service_port | quote ]]
+      tags = [ [[ range $idx, $tag := .outline.outline_group_consul_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+
+      connect {
+        sidecar_service {
+          proxy {
+            [[- range $upstream := .outline.outline_group_upstreams ]]
+            upstreams {
+              destination_name = [[ $upstream.name | quote ]]
+              local_bind_port  = [[ $upstream.port ]]
+            }
+            [[- end ]]
+          }
+        }
+      }
+    }
+
+    restart {
+      attempts = [[ .outline.outline_group_restart_attempts ]]
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "outline" {
+      driver = "docker"
+
+      config {
+        image = [[.outline.outline_task_image | quote]]
+        command = "sh"
+        args = ["-c", "yarn db:migrate --env=production-ssl-disabled && yarn start --env=production-ssl-disabled"]
+      }
+
+      [[- $outline_task_env_vars_length := len .outline.outline_task_env_vars ]]
+      [[- if not (eq $outline_task_env_vars_length 0) ]]
+      env {
+        [[- range $var := .outline.outline_task_env_vars ]]
+        [[ $var.key ]] = [[ $var.value | quote ]]
+        [[- end ]]
+      }
+      [[- end ]]
+
+      resources {
+        cpu    = [[ .outline.outline_task_resources.cpu ]]
+        memory = [[ .outline.outline_task_resources.memory ]]
+      }
+    }
+  }
+}

--- a/packs/outline/variables.hcl
+++ b/packs/outline/variables.hcl
@@ -1,0 +1,555 @@
+// Job variables
+variable "job_name" {
+  description = "The name to use as the job name which overrides using the pack name"
+  type        = string
+  // If "", the pack name will be used
+  default = ""
+}
+
+variable "region" {
+  description = "The region where jobs will be deployed"
+  type        = string
+  default     = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement"
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+// PostgreSQL variables
+variable "postgresql_group_update" {
+  description = "The PostgreSQL update configuration options."
+  type        = object({
+    min_healthy_time  = string
+    healthy_deadline  = string
+    progress_deadline = string
+    auto_revert       = bool
+  })
+  default = {
+    min_healthy_time  = "10s",
+    healthy_deadline  = "5m",
+    progress_deadline = "10m",
+    auto_revert       = true,
+  }
+}
+
+variable "postgresql_group_consul_service_name" {
+  description = "The consul service name for PostgreSQL."
+  type        = string
+  default     = "outline-postgresql"
+}
+
+variable "postgresql_group_consul_service_port" {
+  description = "The consul service port for PostgreSQL."
+  type        = string
+  default     = "5432"
+}
+
+variable "postgresql_group_consul_tags" {
+  description = ""
+  type = list(string)
+  default = [
+    "database"
+  ]
+}
+
+variable "postgresql_group_restart_attempts" {
+  description = "The number of times the task should restart on updates"
+  type        = number
+  default     = 2
+}
+
+variable "postgresql_task_image" {
+  description = "PostgreSQL's Docker image."
+  type        = string
+  default     = "bitnami/postgresql:13.4.0-debian-10-r77"
+}
+
+variable "postgresql_task_volume_path" {
+  description = "The volume's absolute path in the host to be used by PostgreSQL."
+  type        = string
+  default     = "/var/lib/outline/postgresql"
+}
+
+variable "postgresql_task_env_vars" {
+  description = "PostgreSQL's environment variables."
+  type = list(object({
+    key   = string
+    value = string
+  }))
+  default = [
+    {
+      key   = "ALLOW_EMPTY_PASSWORD"
+      value = "no"
+    },
+    {
+      key   = "POSTGRESQL_USERNAME"
+      value = "outline_user"
+    },
+    {
+      key   = "POSTGRESQL_PASSWORD"
+      value = "outline_user_password"
+    },
+    {
+      key   = "POSTGRESQL_DATABASE"
+      value = "outline"
+    }
+  ]
+}
+
+variable "postgresql_task_resources" {
+  description = "The resources to assign to the PostgreSQL service."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 256,
+    memory = 256
+  }
+}
+
+variable "postgresql_data_folder_task_resources" {
+  description = "The resources to assign to the PostgreSQL prestart task."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 20,
+    memory = 20
+  }
+}
+
+// MinIO variables
+variable "minio_group_network" {
+  description = ""
+  type = list(object({
+    name = string
+    port = number
+  }))
+
+  default = [{
+    name = "http"
+    port = 9000
+  }]
+}
+
+variable "minio_group_update" {
+  description = "The MinIO update configuration options."
+  type        = object({
+    min_healthy_time  = string
+    healthy_deadline  = string
+    progress_deadline = string
+    auto_revert       = bool
+  })
+  default = {
+    min_healthy_time  = "10s",
+    healthy_deadline  = "5m",
+    progress_deadline = "10m",
+    auto_revert       = true,
+  }
+}
+
+variable "minio_group_consul_service_name" {
+  description = "The consul service name for MinIO."
+  type        = string
+  default     = "outline-minio"
+}
+
+variable "minio_group_consul_service_port" {
+  description = "The consul service port for MinIO."
+  type        = string
+  default     = "http"
+}
+
+variable "minio_group_consul_tags" {
+  description = ""
+  type = list(string)
+  default = [
+    "database"
+  ]
+}
+
+variable "minio_group_restart_attempts" {
+  description = "The number of times the task should restart on updates"
+  type        = number
+  default     = 2
+}
+
+variable "minio_task_image" {
+  description = "MinIO's Docker image."
+  type        = string
+  default     = "bitnami/minio:2021.10.27-debian-10-r2"
+}
+
+variable "minio_task_volume_path" {
+  description = "The volume's absolute path in the host to be used by MinIO."
+  type        = string
+  default     = "/var/lib/outline/minio"
+}
+
+variable "minio_task_env_vars" {
+  description = "MinIO's environment variables."
+  type = list(object({
+    key   = string
+    value = string
+  }))
+  default = [
+    {
+      key   = "MINIO_ROOT_USER"
+      value = "minio_root_user"
+    },
+    {
+      key   = "MINIO_ROOT_PASSWORD"
+      value = "minio_root_password"
+    },
+    {
+      key   = "MINIO_BROWSER"
+      value = "off"
+    },
+    {
+      key   = "MINIO_DEFAULT_BUCKETS"
+      value = "outline:none"
+    },
+    {
+      key   = "MINIO_FORCE_NEW_KEYS"
+      value = "yes"
+    }
+  ]
+}
+
+variable "minio_task_resources" {
+  description = "The resources to assign to the MinIO service."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 256,
+    memory = 256
+  }
+}
+
+variable "minio_data_folder_task_resources" {
+  description = "The resources to assign to the MinIO prestart task."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 20,
+    memory = 20
+  }
+}
+
+variable "minio_apply_policy_task_resources" {
+  description = "The resources to assign to the MinIO poststart task."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 20,
+    memory = 20
+  }
+}
+
+// Redis variables
+variable "redis_group_update" {
+  description = "The Redis update configuration options."
+  type        = object({
+    min_healthy_time  = string
+    healthy_deadline  = string
+    progress_deadline = string
+    auto_revert       = bool
+  })
+  default = {
+    min_healthy_time  = "10s",
+    healthy_deadline  = "5m",
+    progress_deadline = "10m",
+    auto_revert       = true,
+  }
+}
+
+variable "redis_group_consul_service_name" {
+  description = "The consul service name for Redis."
+  type        = string
+  default     = "outline-redis"
+}
+
+variable "redis_group_consul_service_port" {
+  description = "The consul service port for Redis."
+  type        = string
+  default     = "6379"
+}
+
+variable "redis_group_consul_tags" {
+  description = ""
+  type = list(string)
+  default = [
+    "database"
+  ]
+}
+
+variable "redis_group_restart_attempts" {
+  description = "The number of times the task should restart on updates."
+  type        = number
+  default     = 2
+}
+
+variable "redis_task_image" {
+  description = "Redis's Docker image."
+  type        = string
+  default     = "bitnami/redis:6.2.6-debian-10-r24"
+}
+
+variable "redis_task_volume_path" {
+  description = "The volume's absolute path in the host to be used by Redis."
+  type        = string
+  default     = "/var/lib/outline/redis"
+}
+
+variable "redis_task_env_vars" {
+  description = "Redis' environment variables."
+  type = list(object({
+    key   = string
+    value = string
+  }))
+  default = [
+    {
+      key   = "ALLOW_EMPTY_PASSWORD"
+      value = "no"
+    },
+    {
+      key   = "REDIS_PASSWORD"
+      value = "redis_password"
+    }
+  ]
+}
+
+variable "redis_task_resources" {
+  description = "The resources to assign to the Redis service."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 256,
+    memory = 256
+  }
+}
+
+variable "redis_data_folder_task_resources" {
+  description = "The resources to assign to the Redis prestart task."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 20,
+    memory = 20
+  }
+}
+
+// Outline variables
+variable "outline_group_network" {
+  description = ""
+  type = list(object({
+    name = string
+    port = number
+  }))
+
+  default = [{
+    name = "http"
+    port = 3000
+  }]
+}
+
+variable "outline_group_update" {
+  description = "The Outline update configuration options."
+  type        = object({
+    min_healthy_time  = string
+    healthy_deadline  = string
+    progress_deadline = string
+    auto_revert       = bool
+  })
+  default = {
+    min_healthy_time  = "10s",
+    healthy_deadline  = "5m",
+    progress_deadline = "10m",
+    auto_revert       = true,
+  }
+}
+
+variable "outline_group_consul_service_name" {
+  description = "The consul service name for the application."
+  type        = string
+  default     = "outline"
+}
+
+variable "outline_group_consul_service_port" {
+  description = "The consul service port for the application."
+  type        = string
+  default     = "http"
+}
+
+variable "outline_group_consul_tags" {
+  description = ""
+  type = list(string)
+  default = [
+    "app"
+  ]
+}
+
+variable "outline_group_upstreams" {
+  description = "Consul Connect upstream configuration."
+  type = list(object({
+    name = string
+    port = number
+  }))
+  default = [{
+    name = "outline-postgresql"
+    port = 5432
+  },
+  {
+    name = "outline-minio"
+    port = 9000
+  },
+  {
+    name = "outline-redis"
+    port = 6379
+  }]
+}
+
+variable "outline_group_restart_attempts" {
+  description = "The number of times the task should restart on updates"
+  type        = number
+  default     = 2
+}
+
+variable "outline_task_image" {
+  description = "Outline Docker image."
+  type        = string
+  default     = "outlinewiki/outline:0.59.0"
+}
+
+variable "outline_task_env_vars" {
+  description = "Outline environment variables."
+  type = list(object({
+    key   = string
+    value = string
+  }))
+    default = [
+    {
+      key   = "SECRET_KEY"
+      value = "d1434eff0725153e1cc457a013b53dbcdba6a2b40f00729be5680b56fc003897"
+    },
+    {
+      key   = "UTILS_SECRET"
+      value = "d5c59234b0018fe6036b0376d022c7f5187feb8cc1769c7bc4c282ed8a983b54"
+    },
+    {
+      key   = "REDIS_URL"
+      value = "redis://:redis_password@$${NOMAD_UPSTREAM_ADDR_outline-redis}"
+    },
+    {
+      key   = "DATABASE_URL"
+      value = "postgres://outline_user:outline_user_password@$${NOMAD_UPSTREAM_ADDR_outline-postgresql}/outline"
+    },
+    {
+      key   = "DATABASE_URL_TEST"
+      value = "postgres://outline_user:outline_user_password@$${NOMAD_UPSTREAM_ADDR_outline-postgresql}/outline_test"
+    },
+    {
+      key   = "PGSSLMODE"
+      value = "disable"
+    },
+    {
+      key   = "URL"
+      value = "http://localhost:3000"
+    },
+    {
+      key   = "PORT"
+      value = "3000"
+    },
+    {
+      key   = "AWS_ACCESS_KEY_ID"
+      value = "minio_root_user"
+    },
+    {
+      key   = "AWS_SECRET_ACCESS_KEY"
+      value = "minio_root_password"
+    },
+    {
+      key   = "AWS_REGION"
+      value = "us-east-1"
+    },
+    {
+      key   = "AWS_S3_UPLOAD_BUCKET_URL"
+      value = "http://localhost:9000"
+    },
+    {
+      key   = "AWS_S3_UPLOAD_BUCKET_NAME"
+      value = "outline"
+    },
+    {
+      key   = "AWS_S3_UPLOAD_MAX_SIZE"
+      value = "26214400"
+    },
+    {
+      key   = "AWS_S3_FORCE_PATH_STYLE"
+      value = "true"
+    },
+    {
+      key   = "AWS_S3_ACL"
+      value = "private"
+    },
+    {
+      key   = "SLACK_KEY"
+      value = "123123"
+    },
+    {
+      key   = "SLACK_SECRET"
+      value = "123123"
+    },
+    {
+      key   = "FORCE_HTTPS"
+      value = "false"
+    },
+    {
+      key   = "ENABLE_UPDATES"
+      value = "no"
+    },
+    {
+      key   = "WEB_CONCURRENCY"
+      value = "1"
+    },
+    {
+      key   = "MAXIMUM_IMPORT_SIZE"
+      value = "5120000"
+    },
+    {
+      key   = "DEBUG"
+      value = "http"
+    },
+    {
+      key   = "DEFAULT_LANGUAGE"
+      value = "en_US"
+    }
+  ]
+}
+
+variable "outline_task_resources" {
+  description = "The resources to assign to the Outline service."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 512,
+    memory = 256
+  }
+}

--- a/packs/outline/variables.hcl
+++ b/packs/outline/variables.hcl
@@ -19,6 +19,11 @@ variable "constraints" {
       value     = "true",
       operator  = "",
     },
+    {
+      attribute = "$${attr.driver.raw_exec}",
+      value     = "1",
+      operator  = "",
+    }
   ]
 }
 

--- a/packs/outline/variables.hcl
+++ b/packs/outline/variables.hcl
@@ -6,6 +6,22 @@ variable "job_name" {
   default = ""
 }
 
+variable "constraints" {
+  description = "Constraints to apply to the entire job. Docker Volumes are required due to databases."
+  type        = list(object({
+    attribute = string
+    operator  = string
+    value     = string
+  }))
+  default = [
+    {
+      attribute = "$${attr.driver.docker.volumes.enabled}",
+      value     = "true",
+      operator  = "",
+    },
+  ]
+}
+
 variable "region" {
   description = "The region where jobs will be deployed"
   type        = string


### PR DESCRIPTION
Hello again!

This pack contains a service job that runs [Outline](https://www.getoutline.com/) in a single Nomad client. It currently supports
being run by the [Docker](https://www.nomadproject.io/docs/drivers/docker) driver.

It has 4 tasks:
- **Outline:** [*(reference)*](https://www.getoutline.com/) the wiki and knowledgebase for teams;
- **PostgreSQL:** [*(reference)*](https://www.postgresql.org/) the persistent database used by Outline;
- **Redis:** [*(reference)*](https://redis.io/) for in-memory storage and cache;
- **MinIO:** [*(reference)*](https://min.io/) for images storage, compatible with S3 cloud storage service.

Setup:
- Service-to-service communication is handled with Consul Connect;
- Bitnami images are being used for [PostgreSQL](https://hub.docker.com/r/bitnami/postgresql), [Redis](https://hub.docker.com/r/bitnami/redis) and [MinIO](https://hub.docker.com/r/bitnami/minio). They are non-root containers and as such the mounted files and directories must have the proper permissions for the UID 1001. To achieve this, these 3 images are being run as user 1001 and there are prestart tasks that create their respective directories, while setting the correct ownership, in the host filesystem with the raw exec driver;
- Only MinIO and Outline ports are exposed. To simplify the pack, MinIO has a static host port of 9000, whereas Outline's port is being randomly assigned. In production it's recommended that none of the services are directly exposed and that traffic is run through a reverse proxy that supports Consul Connect enabled services, like Traefik;
- MinIO's group has a poststart task that applies a policy that disables directory browsing. It does it by finding the correct Docker container, exec'ing into the container and applying the policy with MinIO's MC;
- Outline supports a number of authentication methods. Slack is used for demonstration purposes, but enabling more authentication methods is a matter of defining the [environment variables](https://github.com/outline/outline/blob/main/.env.sample);
- The default variables are defined for a local setup.

Thank you