### PR TITLE
Add Faasd pack

### DIFF
--- a/packs/faasd/README.md
+++ b/packs/faasd/README.md
@@ -1,0 +1,26 @@
+# faasd
+
+This pack contains all you need to deploy faasd (version 2 by default) in Nomad. It uses Docker driver.
+
+
+## Variables
+
+- `job_name` (string) - The name to use as the job name which overrides using the pack name.
+- `region` (string) - The region where jobs will be deployed.
+- `datacenters` (list of strings) - A list of datacenters in the region which are eligible for task placement.
+- `namespace` (string) - The namespace where the job should be placed.
+- `constraints` (string) - Constraints to apply to the entire job.
+- `image_name` (string) - The docker image name.
+- `image_tag` (string) - The docker image tag.
+- `task_resources` (object, number number) Resources used by faasd task
+- `register_consul_service` (bool) - If you want to register a consul service for the job
+- `consul_service_name` (string) - The consul service name for the hello-world application
+- `consul_service_tags` (list of string) - The consul service name for the hello-world application
+- `volume_name` (string) - The name of the volume you want faasd to use
+- `volume_type` (string) - The type of the volume you want faasd to use
+- `docker_faasd_env_vars` (map of string) - Environment variables to pass to Docker container
+
+## faasd Environment Variables
+
+You can pass the right environment variables to faasd.
+An example of the `docker_faasd_env_vars` to use is in the `vars.nomad` file.

--- a/packs/faasd/README.md
+++ b/packs/faasd/README.md
@@ -10,15 +10,33 @@ This pack contains all you need to deploy faasd (version 2 by default) in Nomad.
 - `datacenters` (list of strings) - A list of datacenters in the region which are eligible for task placement.
 - `namespace` (string) - The namespace where the job should be placed.
 - `constraints` (string) - Constraints to apply to the entire job.
-- `image_name` (string) - The docker image name.
-- `image_tag` (string) - The docker image tag.
-- `task_resources` (object, number number) Resources used by faasd task
-- `register_consul_service` (bool) - If you want to register a consul service for the job
-- `consul_service_name` (string) - The consul service name for the hello-world application
-- `consul_service_tags` (list of string) - The consul service name for the hello-world application
-- `volume_name` (string) - The name of the volume you want faasd to use
-- `volume_type` (string) - The type of the volume you want faasd to use
-- `docker_faasd_env_vars` (map of string) - Environment variables to pass to Docker container
+- `nats_image_name` (string) - The Nats docker image name
+- `auth_plugin_image_name` (string) - The Authentication docker image name
+- `gateway_image_name` (string) - The Gateway docker image name
+- `queue_worker_image_name` (string) - The Queue Worker docker image name
+- `faasd_version` (string) - The Faasd version number
+- `nats_image_tag` (string) - The Nats docker image tag
+- `auth_plugin_image_tag` (string) - The Authentication docker image tag
+- `gateway_image_tag` (string) - The Gateway docker image tag
+- `queue_worker_image_tag` (string) - The Queue Worker docker image tag
+- `faasd_provider_task_resources` (object, number number) - Resources used by Faasd task
+- `nats_task_resources` (object, number number) - Resources used by Nats task
+- `basic_auth_task_resources` (object, number number) - Resources used by Authentication task
+- `gateway_task_resources` (object, number number) - Resources used by Gateway task
+- `queue_worker_task_resources` (object, number number) - Resources used by Queue Worker task
+- `register_auth_consul_service` (bool) - If you want to register a consul service for the Authentication task
+- `register_nats_consul_service` (bool) - If you want to register a consul service for the Nats task
+- `register_gateway_consul_service` (bool) - If you want to register a consul service for the Gateway task
+- `register_provider_consul_service` bool() - If you want to register a consul service for the Faasd provider task
+- `auth_consul_service_name` (string) - The consul service name for the Authentication task 
+- `provider_consul_service_name` (string) - The consul service name for the Faasd provider task
+- `nats_consul_service_name` (string) - The consul service name for the Nats task
+- `gateway_consul_service_name` (string) - The consul service name for the Gateway task
+- `consul_service_tags` (list of strings) - The consul service name for the Faasd application
+- `dns_servers` (list of strings) - To add custom dns servers
+- `basic_auth_user` (string) - The authentication username
+- `basic_auth_password` (string) - The authentication password
+- `docker_faasd_env_vars` (map of strings) - Environment variables to pass to Docker container
 
 ## faasd Environment Variables
 

--- a/packs/faasd/metadata.hcl
+++ b/packs/faasd/metadata.hcl
@@ -1,6 +1,6 @@
 app {
-  url    = "https://github.com/hashicorp/nomad-pack"
-  author = "HashiCorp"
+  url    = "https://www.openfaas.com"
+  author = "Openfaas"
 }
 
 pack {

--- a/packs/faasd/metadata.hcl
+++ b/packs/faasd/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = "https://github.com/hashicorp/nomad-pack"
+  author = "HashiCorp"
+}
+
+pack {
+  name        = "faasd"
+  description = "Faasd is OpenFaaS reimagined, but without the cost and complexity of Kubernetes."
+  url         = "https://github.com/hashicorp/nomad-pack-community-registry/faasd"
+  version     = "0.0.1"
+}

--- a/packs/faasd/outputs.tpl
+++ b/packs/faasd/outputs.tpl
@@ -1,0 +1,1 @@
+Congrats on deploying [[ .nomad_pack.pack.name ]].

--- a/packs/faasd/templates/_helpers.tpl
+++ b/packs/faasd/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+// allow nomad-pack to set the job name
+
+[[- define "job_name" -]]
+[[- if eq .faasd.job_name "" -]]
+[[- .nomad_pack.pack.name | quote -]]
+[[- else -]]
+[[- .faasd.job_name | quote -]]
+[[- end -]]
+[[- end -]]
+
+// only deploys to a region if specified
+
+[[- define "region" -]]
+[[- if not (eq .faasd.region "") -]]
+region = [[ .faasd.region | quote]]
+[[- end -]]
+[[- end -]]

--- a/packs/faasd/templates/faasd.nomad.tpl
+++ b/packs/faasd/templates/faasd.nomad.tpl
@@ -191,7 +191,7 @@ job [[ template "job_name" . ]] {
       }
     }
 
-    task "basic-auth-plugin" {
+    task "basic_auth_plugin" {
       driver = "docker"
 
       config {
@@ -258,7 +258,7 @@ job [[ template "job_name" . ]] {
       }
     }
 
-    task "queue-worker" {
+    task "queue_worker" {
       driver = "docker"
       config {
         image = "[[.faasd.queue_worker_image_name]]:[[.faasd.queue_worker_image_tag]]"

--- a/packs/faasd/templates/faasd.nomad.tpl
+++ b/packs/faasd/templates/faasd.nomad.tpl
@@ -1,0 +1,292 @@
+job [[ template "job_name" . ]] {
+  [[ template "region" . ]]
+  datacenters = [ [[ range $idx, $dc := .faasd.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  type = "service"
+  [[ if .faasd.namespace ]]
+  namespace   = [[ .faasd.namespace | quote ]]
+  [[end]]
+  [[ if .faasd.constraints ]][[ range $idx, $constraint := .faasd.constraints ]]
+  constraint {
+    [[- if ne $constraint.attribute "" ]]
+    attribute = [[ $constraint.attribute | quote ]]
+    [[- end ]]
+    [[- if ne $constraint.value "" ]]
+    value     = [[ $constraint.value | quote ]]
+    [[- end ]]
+    [[- if ne $constraint.operator "" ]]
+    operator  = [[ $constraint.operator | quote ]]
+    [[- end ]]
+  }
+  [[- end ]]
+  [[- end ]]
+
+  group [[ template "job_name" . ]] {
+    count = 1
+
+    network {
+      port "faasd_http" {
+        static = 8081
+        to     = 8081
+      }
+      port "auth_http" {}
+      port "nats_tcp" {}
+      port "nats_tcp_1" {
+        to = 6222
+      }
+      port "nats_mon" {}
+      port "gateway_http" {
+        to = 8080
+      }
+      port "gateway_mon" {
+        to = 8082
+      }
+    }
+
+    [[ if .faasd.register_auth_consul_service ]]
+    service {
+      name = "[[ .faasd.consul_service_name ]]"
+      [[if ne (len .faasd.consul_service_tags) 0 ]]
+      tags = [ [[ range $idx, $tag := .faasd.consul_service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+      [[ end ]]
+      port = "auth_http"
+
+      check {
+        type     = "tcp"
+        port     = "auth_http"
+        interval = "5s"
+        timeout  = "2s"
+      }
+    }
+    [[ end ]]
+
+    [[ if .faasd.register_nats_consul_service ]]
+    service {
+      name = "[[ .faasd.consul_service_name ]]"
+      [[if ne (len .faasd.consul_service_tags) 0 ]]
+      tags = [ [[ range $idx, $tag := .faasd.consul_service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+      [[ end ]]
+      port = "nats_tcp"
+
+      check {
+        type     = "tcp"
+        port     = "nats_tcp"
+        interval = "5s"
+        timeout  = "2s"
+      }
+    }
+    [[ end ]]
+
+    [[ if .faasd.register_gateway_consul_service ]]
+    service {
+      name = "[[ .faasd.consul_service_name ]]"
+      [[if ne (len .faasd.consul_service_tags) 0 ]]
+      tags = [ [[ range $idx, $tag := .faasd.consul_service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+      [[ end ]]
+      port = "gateway_http"
+
+      check {
+        type     = "tcp"
+        port     = "gateway_http"
+        interval = "5s"
+        timeout  = "2s"
+      }
+    }
+    [[ end ]]
+
+    [[ if .faasd.register_monitoring_consul_service ]]
+    service {
+      name = "[[ .faasd.consul_service_name ]]"
+      [[if ne (len .faasd.consul_service_tags) 0 ]]
+      tags = [ [[ range $idx, $tag := .faasd.consul_service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+      [[ end ]]
+      port = "gateway_monitoring"
+
+      check {
+        type     = "http"
+        path     = "/metrics"
+        port     = "gateway_mon"
+        interval = "30s"
+        timeout  = "2s"
+      }
+    }
+    [[ end ]]
+
+    [[ if .faasd.register_provider_consul_service ]]
+    service {
+      name = "[[ .faasd.provider_consul_service_name ]]"
+      [[if ne (len .faasd.provider_consul_service_tags) 0 ]]
+      tags = [ [[ range $idx, $tag := .faasd.consul_service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+      [[ end ]]
+      port = "faasd_http"
+
+      check {
+        type     = "tcp"
+        port     = "faasd_http"
+        interval = "5s"
+        timeout  = "2s"
+      }
+    }
+    [[ end ]]
+
+    [[ if .faasd.volume_name ]]
+    volume "[[.faasd.volume_name]]" {
+      type      = "[[.faasd.volume_type]]"
+      read_only = false
+      source    = "[[.faasd.volume_name]]"
+    }
+    [[end]]
+
+    restart {
+      attempts = 2
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "download-faasd" {
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
+      }
+
+      driver = "raw_exec"
+      config {
+        command = "sh"
+        args    = ["-c", "wget -q https://github.com/openfaas/faasd/releases/download/${faasd_version}/faasd && mv faasd /usr/local/bin/faasd && chmod +x /usr/local/bin/faasd"]
+      }
+    }
+
+    task "faasd_provider" {
+      driver = "raw_exec"
+      config {
+        command = "/usr/local/bin/faasd"
+        args    = ["provider"]
+      }
+      resources {
+        cpu    = [[ .faasd.faasd_provider_task_resources.cpu ]]
+        memory = [[ .faasd.faasd_provider_task_resources.memory ]]
+      }
+    }
+
+    task "nats" {
+      driver = "docker"
+      config {
+        image      = "[[.faasd.nats_image_name]]:[[.faasd.nats_image_tag]]"
+        ports      = ["nats_tcp", "nats_tcp_1"]
+        entrypoint = ["/nats-streaming-server"]
+        args = [
+          "-p",
+          "$${NOMAD_PORT_nats_tcp}",
+          "-m",
+          "$${NOMAD_PORT_nats_mon}",
+          "--store=memory",
+          "--cluster_id=faas-cluster",
+          "-DV"
+        ]
+      }
+      resources {
+        cpu    = [[ .faasd.nats_task_resources.cpu ]]
+        memory = [[ .faasd.nats_task_resources.memory ]]
+      }
+    }
+
+    task "basic-auth-plugin" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/openfaas/basic-auth:${faas_auth_plugin_version}"
+        ports = ["auth_http"]
+
+      }
+
+      template {
+        data        = "password"
+        destination = "secrets/basic-auth-password"
+      }
+
+      template {
+        data        = "admin"
+        destination = "secrets/basic-auth-user"
+      }
+
+      env {
+        port              = "${NOMAD_PORT_auth_http}"
+        secret_mount_path = "/secrets/"
+        user_filename     = "basic-auth-user"
+        pass_filename     = "basic-auth-password"
+      }
+
+      resources {
+        cpu    = [[ .faasd.basic_auth_task_resources.cpu ]]
+        memory = [[ .faasd.basic_auth_task_resources.memory ]]
+      }
+    }
+
+    task "gateway" {
+      driver = "docker"
+      config {
+        image = "ghcr.io/openfaas/gateway:${faas_gateway_version}"
+        ports = ["gateway_http", "gateway_mon"]
+      }
+      template {
+        data        = "password"
+        destination = "secrets/basic-auth-password"
+      }
+      template {
+        data        = "admin"
+        destination = "secrets/basic-auth-user"
+      }
+      env {
+        basic_auth             = "true"
+        functions_provider_url = [[if .faasd.register_provider_consul_service ]]"http://[[.faasd.provider_consul_service_name]].service.consul:${NOMAD_PORT_faasd_http}/"]][[else]]"http://${NOMAD_ADDR_faasd_http}/"[[end]]
+        direct_functions       = "false"
+        read_timeout           = "60s"
+        write_timeout          = "60s"
+        upstream_timeout       = "65s"
+        faas_prometheus_host   = "${NOMAD_HOST_IP_gateway_http}"
+        faas_nats_address      = "faasd-nats.service.consul"
+        faas_nats_port         = "${NOMAD_PORT_nats_tcp}"
+        auth_proxy_url         = [[if .faasd.register_basic_auth_consul_service ]]"http://[[.faasd.basic_auth_consul_service_name]].service.consul:$${NOMAD_PORT_auth_http}/validate"[[else]]http://${NOMAD_ADDR_auth_http}/validate[[end]]
+        auth_proxy_pass_body   = "false"
+        secret_mount_path      = "/secrets"
+        scale_from_zero        = "true"
+        function_namespace     = "openfaas-fn"
+      }
+      resources {
+        cpu    = [[ .faasd.gateway_task_resources.cpu ]]
+        memory = [[ .faasd.gateway_task_resources.memory ]]
+      }
+    }
+
+    task "queue-worker" {
+      driver = "docker"
+      config {
+        image = "ghcr.io/openfaas/queue-worker:${faas_queue_worker_version}"
+      }
+      template {
+        data        = "password"
+        destination = "secrets/basic-auth-password"
+      }
+
+      template {
+        data        = "admin"
+        destination = "secrets/basic-auth-user"
+      }
+      env {
+        faas_nats_address    = [[if .faasd.register_auth_consul_service]]"faasd-nats.service.consul"[[else]]${NOMAD_IP_gateway_http}[[end]]
+        faas_nats_port       = "${NOMAD_PORT_nats_tcp}"
+        gateway_invoke       = "true"
+        faas_gateway_address = [[if .faasd.register_gateway_consul_service]]"faads-gateway.service.consul:${NOMAD_PORT_gateway_http}"[[else]]${NOMAD_ADDR_gateway_http}[[end]]
+        ack_wait             = "5m5s"
+        max_inflight         = "1"
+        write_debug          = "true"
+        basic_auth           = "true"
+        secret_mount_path    = "/secrets"
+      }
+      resources {
+        cpu    = [[ .faasd.queue_worker_task_resources.cpu ]]
+        memory = [[ .faasd.queue_worker_task_resources.memory ]]
+      }
+    }
+  }
+}

--- a/packs/faasd/templates/faasd.nomad.tpl
+++ b/packs/faasd/templates/faasd.nomad.tpl
@@ -143,7 +143,7 @@ job [[ template "job_name" . ]] {
       mode     = "delay"
     }
 
-    task "download-faasd" {
+    task "prepare_faasd" {
       lifecycle {
         hook    = "prestart"
       }

--- a/packs/faasd/templates/faasd.nomad.tpl
+++ b/packs/faasd/templates/faasd.nomad.tpl
@@ -1,11 +1,11 @@
 job [[ template "job_name" . ]] {
   [[ template "region" . ]]
-  datacenters = [ [[ range $idx, $dc := .faasd.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .faasd.datacenters | toPrettyJson ]]
   type = "service"
-  [[ if .faasd.namespace ]]
+  [[- if .faasd.namespace ]]
   namespace   = [[ .faasd.namespace | quote ]]
-  [[end]]
-  [[ if .faasd.constraints ]][[ range $idx, $constraint := .faasd.constraints ]]
+  [[- end]]
+  [[- if .faasd.constraints ]][[ range $idx, $constraint := .faasd.constraints ]]
   constraint {
     [[- if ne $constraint.attribute "" ]]
     attribute = [[ $constraint.attribute | quote ]]
@@ -24,29 +24,36 @@ job [[ template "job_name" . ]] {
     count = 1
 
     network {
-      port "faasd_http" {
+      port "faasd_provider_tcp" {
         static = 8081
         to     = 8081
       }
       port "auth_http" {}
-      port "nats_tcp" {}
-      port "nats_tcp_1" {
-        to = 6222
+      port "nats_tcp_client" {
+        to = 4222
       }
-      port "nats_mon" {}
+      port "nats_http_mon" {
+        to = 8222
+      }
       port "gateway_http" {
         to = 8080
       }
       port "gateway_mon" {
         to = 8082
       }
+
+      [[- if ne (len .faasd.dns_servers) 0]]
+      dns {
+        servers = [[ .faasd.dns_servers | toPrettyJson ]]
+      }
+      [[- end]]
     }
 
-    [[ if .faasd.register_auth_consul_service ]]
+    [[- if .faasd.register_auth_consul_service ]]
     service {
-      name = "[[ .faasd.consul_service_name ]]"
+      name = "[[ .faasd.auth_consul_service_name ]]"
       [[if ne (len .faasd.consul_service_tags) 0 ]]
-      tags = [ [[ range $idx, $tag := .faasd.consul_service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+      tags = [[ .faasd.consul_service_tags | toPrettyJson ]]
       [[ end ]]
       port = "auth_http"
 
@@ -57,102 +64,97 @@ job [[ template "job_name" . ]] {
         timeout  = "2s"
       }
     }
-    [[ end ]]
+    [[- end ]]
 
-    [[ if .faasd.register_nats_consul_service ]]
+    [[- if .faasd.register_nats_consul_service ]]
     service {
-      name = "[[ .faasd.consul_service_name ]]"
-      [[if ne (len .faasd.consul_service_tags) 0 ]]
-      tags = [ [[ range $idx, $tag := .faasd.consul_service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
-      [[ end ]]
-      port = "nats_tcp"
+      name = "[[ .faasd.nats_consul_service_name ]]"
+      [[- if ne (len .faasd.consul_service_tags) 0 ]]
+      tags = [[ .faasd.consul_service_tags | toPrettyJson ]]
+      [[- end ]]
+      port = "nats_tcp_client"
 
       check {
         type     = "tcp"
-        port     = "nats_tcp"
+        port     = "nats_tcp_client"
         interval = "5s"
         timeout  = "2s"
       }
     }
-    [[ end ]]
+    [[- end ]]
 
-    [[ if .faasd.register_gateway_consul_service ]]
+    [[- if .faasd.register_nats_consul_service ]]
     service {
-      name = "[[ .faasd.consul_service_name ]]"
-      [[if ne (len .faasd.consul_service_tags) 0 ]]
-      tags = [ [[ range $idx, $tag := .faasd.consul_service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
-      [[ end ]]
+      name = "faasd-nats-monitoring"
+      [[- if ne (len .faasd.nats_consul_service_name) 0 ]]
+      tags = [[ .faasd.consul_service_tags | toPrettyJson ]]
+      [[- end ]]
+      port = "nats_http_mon"
+
+      check {
+        type     = "http"
+        path     = "/connz"
+        port     = "nats_http_mon"
+        interval = "30s"
+        timeout  = "2s"
+      }
+    }
+    [[- end]]
+
+    [[- if .faasd.register_gateway_consul_service ]]
+    service {
+      name = "[[ .faasd.gateway_consul_service_name ]]"
+      [[- if ne (len .faasd.consul_service_tags) 0 ]]
+      tags = [[ .faasd.consul_service_tags | toPrettyJson ]]
+      [[- end ]]
       port = "gateway_http"
 
       check {
-        type     = "tcp"
+        type     = "http"
+        path     = "/healthz"
         port     = "gateway_http"
         interval = "5s"
         timeout  = "2s"
       }
     }
-    [[ end ]]
+    [[- end ]]
 
-    [[ if .faasd.register_monitoring_consul_service ]]
-    service {
-      name = "[[ .faasd.consul_service_name ]]"
-      [[if ne (len .faasd.consul_service_tags) 0 ]]
-      tags = [ [[ range $idx, $tag := .faasd.consul_service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
-      [[ end ]]
-      port = "gateway_monitoring"
-
-      check {
-        type     = "http"
-        path     = "/metrics"
-        port     = "gateway_mon"
-        interval = "30s"
-        timeout  = "2s"
-      }
-    }
-    [[ end ]]
-
-    [[ if .faasd.register_provider_consul_service ]]
+    [[- if .faasd.register_provider_consul_service ]]
     service {
       name = "[[ .faasd.provider_consul_service_name ]]"
-      [[if ne (len .faasd.provider_consul_service_tags) 0 ]]
-      tags = [ [[ range $idx, $tag := .faasd.consul_service_tags ]][[if $idx]],[[end]][[ $tag | quote ]][[ end ]] ]
+      [[if ne (len .faasd.consul_service_tags) 0 ]]
+      tags = [[ .faasd.consul_service_tags | toPrettyJson ]]
       [[ end ]]
-      port = "faasd_http"
+      port = "faasd_provider_tcp"
 
       check {
         type     = "tcp"
-        port     = "faasd_http"
+        port     = "faasd_provider_tcp"
         interval = "5s"
         timeout  = "2s"
       }
     }
-    [[ end ]]
-
-    [[ if .faasd.volume_name ]]
-    volume "[[.faasd.volume_name]]" {
-      type      = "[[.faasd.volume_type]]"
-      read_only = false
-      source    = "[[.faasd.volume_name]]"
-    }
-    [[end]]
+    [[- end ]]
 
     restart {
-      attempts = 2
-      interval = "30m"
-      delay = "15s"
-      mode = "fail"
+      attempts = 3
+      delay    = "5s"
+      interval = "10m"
+      mode     = "delay"
     }
 
     task "download-faasd" {
       lifecycle {
         hook    = "prestart"
-        sidecar = false
       }
 
       driver = "raw_exec"
       config {
         command = "sh"
-        args    = ["-c", "wget -q https://github.com/openfaas/faasd/releases/download/${faasd_version}/faasd && mv faasd /usr/local/bin/faasd && chmod +x /usr/local/bin/faasd"]
+        args    = ["-c", "wget -q https://github.com/openfaas/faasd/releases/download/[[.faasd.faasd_version]]/faasd && mkdir -p /var/lib/faasd && touch /var/lib/faasd/hosts /var/lib/faasd/resolv.conf && mv faasd /usr/local/bin/faasd && chmod +x /usr/local/bin/faasd"]
+      }
+      env {
+        service_timeout = "60s"
       }
     }
 
@@ -172,14 +174,13 @@ job [[ template "job_name" . ]] {
       driver = "docker"
       config {
         image      = "[[.faasd.nats_image_name]]:[[.faasd.nats_image_tag]]"
-        ports      = ["nats_tcp", "nats_tcp_1"]
+        ports      = ["nats_tcp_client", "nats_http_mon"]
         entrypoint = ["/nats-streaming-server"]
         args = [
           "-p",
-          "$${NOMAD_PORT_nats_tcp}",
+          "$${NOMAD_PORT_nats_tcp_client}",
           "-m",
-          "$${NOMAD_PORT_nats_mon}",
-          "--store=memory",
+          "$${NOMAD_PORT_nats_http_mon}",
           "--cluster_id=faas-cluster",
           "-DV"
         ]
@@ -194,18 +195,17 @@ job [[ template "job_name" . ]] {
       driver = "docker"
 
       config {
-        image = "ghcr.io/openfaas/basic-auth:${faas_auth_plugin_version}"
+        image = "[[.faasd.auth_plugin_image_name]]:[[.faasd.auth_plugin_image_tag]]"
         ports = ["auth_http"]
-
       }
 
       template {
-        data        = "password"
+        data        = "[[.faasd.basic_auth_password]]"
         destination = "secrets/basic-auth-password"
       }
 
       template {
-        data        = "admin"
+        data        = "[[.faasd.basic_auth_user]]"
         destination = "secrets/basic-auth-user"
       }
 
@@ -225,28 +225,28 @@ job [[ template "job_name" . ]] {
     task "gateway" {
       driver = "docker"
       config {
-        image = "ghcr.io/openfaas/gateway:${faas_gateway_version}"
+        image = "[[.faasd.gateway_image_name]]:[[.faasd.gateway_image_tag]]"
         ports = ["gateway_http", "gateway_mon"]
       }
       template {
-        data        = "password"
+        data        = "[[.faasd.basic_auth_password]]"
         destination = "secrets/basic-auth-password"
       }
       template {
-        data        = "admin"
+        data        = "[[.faasd.basic_auth_user]]"
         destination = "secrets/basic-auth-user"
       }
       env {
         basic_auth             = "true"
-        functions_provider_url = [[if .faasd.register_provider_consul_service ]]"http://[[.faasd.provider_consul_service_name]].service.consul:${NOMAD_PORT_faasd_http}/"]][[else]]"http://${NOMAD_ADDR_faasd_http}/"[[end]]
+        functions_provider_url = [[if .faasd.register_provider_consul_service ]]"http://[[.faasd.provider_consul_service_name]].service.consul:${NOMAD_HOST_PORT_faasd_provider_tcp}/"[[else]]"http://${NOMAD_ADDR_faasd_provider_tcp}/"[[end]]
         direct_functions       = "false"
         read_timeout           = "60s"
         write_timeout          = "60s"
-        upstream_timeout       = "65s"
+        upstream_timeout       = "60s"
         faas_prometheus_host   = "${NOMAD_HOST_IP_gateway_http}"
-        faas_nats_address      = "faasd-nats.service.consul"
-        faas_nats_port         = "${NOMAD_PORT_nats_tcp}"
-        auth_proxy_url         = [[if .faasd.register_basic_auth_consul_service ]]"http://[[.faasd.basic_auth_consul_service_name]].service.consul:$${NOMAD_PORT_auth_http}/validate"[[else]]http://${NOMAD_ADDR_auth_http}/validate[[end]]
+        faas_nats_address      = [[if .faasd.register_auth_consul_service]]"[[.faasd.nats_consul_service_name]].service.consul"[[else]]"${NOMAD_HOST_IP_nats_tcp_client}"[[end]]
+        faas_nats_port         = "${NOMAD_HOST_PORT_nats_tcp_client}"
+        auth_proxy_url         = [[if .faasd.register_basic_auth_consul_service ]]"http://[[.faasd.basic_auth_consul_service_name]].service.consul:$${NOMAD_HOST_PORT_auth_http}/validate"[[else]]"http://${NOMAD_ADDR_auth_http}/validate"[[end]]
         auth_proxy_pass_body   = "false"
         secret_mount_path      = "/secrets"
         scale_from_zero        = "true"
@@ -261,7 +261,7 @@ job [[ template "job_name" . ]] {
     task "queue-worker" {
       driver = "docker"
       config {
-        image = "ghcr.io/openfaas/queue-worker:${faas_queue_worker_version}"
+        image = "[[.faasd.queue_worker_image_name]]:[[.faasd.queue_worker_image_tag]]"
       }
       template {
         data        = "password"
@@ -273,11 +273,11 @@ job [[ template "job_name" . ]] {
         destination = "secrets/basic-auth-user"
       }
       env {
-        faas_nats_address    = [[if .faasd.register_auth_consul_service]]"faasd-nats.service.consul"[[else]]${NOMAD_IP_gateway_http}[[end]]
-        faas_nats_port       = "${NOMAD_PORT_nats_tcp}"
+        faas_nats_address    = [[if .faasd.register_auth_consul_service]]"[[.faasd.nats_consul_service_name]].service.consul"[[else]]"${NOMAD_HOST_IP_nats_tcp_client}"[[end]]
+        faas_nats_port       = [[if .faasd.register_auth_consul_service]]"${NOMAD_HOST_PORT_nats_tcp_client}"[[else]]"${NOMAD_HOST_PORT_nats_tcp_client}"[[end]]
         gateway_invoke       = "true"
-        faas_gateway_address = [[if .faasd.register_gateway_consul_service]]"faads-gateway.service.consul:${NOMAD_PORT_gateway_http}"[[else]]${NOMAD_ADDR_gateway_http}[[end]]
-        ack_wait             = "5m5s"
+        faas_gateway_address = [[if .faasd.register_gateway_consul_service]]"[[.faasd.gateway_consul_service_name]].service.consul:${NOMAD_HOST_PORT_gateway_http}"[[else]]"${NOMAD_HOST_ADDR_gateway_http}"[[end]]
+        ack_wait             = "60s"
         max_inflight         = "1"
         write_debug          = "true"
         basic_auth           = "true"

--- a/packs/faasd/variables.hcl
+++ b/packs/faasd/variables.hcl
@@ -32,7 +32,7 @@ variable "constraints" {
   default = [
     {
       attribute = "$${attr.kernel.name}",
-      value     = "(linux|darwin)",
+      value     = "linux",
       operator  = "regexp",
     },
   ]

--- a/packs/faasd/variables.hcl
+++ b/packs/faasd/variables.hcl
@@ -44,7 +44,7 @@ variable "nats_image_name" {
   default     = "docker.io/library/nats-streaming"
 }
 
-variable "basic_auth_image_name" {
+variable "auth_plugin_image_name" {
   description = "The faasd basic auth docker image name."
   type        = string
   default     = "ghcr.io/openfaas/basic-auth"
@@ -62,9 +62,9 @@ variable "queue_worker_image_name" {
   default     = "ghcr.io/openfaas/queue-worker"
 }
 
-variable "faasd_image_tag" {
+variable "faasd_version" {
   type    = string
-  default = "0.13.0"
+  default = "0.14.3"
 }
 
 variable "nats_image_tag" {
@@ -173,10 +173,10 @@ variable "register_provider_consul_service" {
   default     = false
 }
 
-variable "basic_auth_consul_service_name" {
+variable "auth_consul_service_name" {
   description = "The consul service name for the basic authentication task."
   type        = string
-  default     = "basic-auth"
+  default     = "faasd-auth"
 }
 
 variable "provider_consul_service_name" {
@@ -188,30 +188,37 @@ variable "provider_consul_service_name" {
 variable "nats_consul_service_name" {
   description = "The consul service name for the nats task."
   type        = string
-  default     = "nats"
+  default     = "faasd-nats"
 }
 
 variable "gateway_consul_service_name" {
   description = "The consul service name for the gateway task."
   type        = string
-  default     = "gateway"
+  default     = "faasd-gateway"
 }
 
-variable "faasd_monitoring_consul_service_name" {
-  description = "The consul service name for the monitoring task."
-  type        = string
-  default     = "faasd-monitoring"
+variable "consul_service_tags" {
+  description = "The consul service name for the application."
+  type        = list(string)
+  default     = []
 }
 
-variable "volume_name" {
-  description = "The name of the volume you want faasd to use."
-  type        = string
+variable "dns_servers" {
+  description = "The dns server(s) you want faasd service resolve names to"
+  type        = list(string)
+  default     = []
 }
 
-variable "volume_type" {
-  description = "The type of the volume you want faasd to use."
-  type        = string
-  default     = "host"
+variable "basic_auth_user" {
+  description = "Username for Faasd gateway authentication"
+  type = string
+  default = "admin"
+}
+
+variable "basic_auth_password" {
+  description = "Password for Faasd gateway authentication"
+  type = string
+  default = "password"
 }
 
 variable "docker_faasd_env_vars" {

--- a/packs/faasd/variables.hcl
+++ b/packs/faasd/variables.hcl
@@ -162,11 +162,6 @@ variable "register_gateway_consul_service" {
   type        = bool
   default     = false
 }
-variable "register_monitoring_consul_service" {
-  description = "If you want to register a consul service for the monitoring task."
-  type        = bool
-  default     = false
-}
 variable "register_provider_consul_service" {
   description = "If you want to register a consul service for the provider task."
   type        = bool

--- a/packs/faasd/variables.hcl
+++ b/packs/faasd/variables.hcl
@@ -1,0 +1,223 @@
+variable "job_name" {
+  description = "The name to use as the job name which overrides using the pack name."
+  type        = string
+  // If "", the pack name will be used
+  default = "faasd"
+}
+
+variable "region" {
+  description = "The region where jobs will be deployed."
+  type        = string
+  default     = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement."
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "namespace" {
+  description = "The namespace where the job should be placed."
+  type        = string
+}
+
+variable "constraints" {
+  description = "Constraints to apply to the entire job."
+  type = list(object({
+    attribute = string
+    operator  = string
+    value     = string
+  }))
+  default = [
+    {
+      attribute = "$${attr.kernel.name}",
+      value     = "(linux|darwin)",
+      operator  = "regexp",
+    },
+  ]
+}
+
+variable "nats_image_name" {
+  description = "The nats docker image name."
+  type        = string
+  default     = "docker.io/library/nats-streaming"
+}
+
+variable "basic_auth_image_name" {
+  description = "The faasd basic auth docker image name."
+  type        = string
+  default     = "ghcr.io/openfaas/basic-auth"
+}
+
+variable "gateway_image_name" {
+  description = "The gateway docker image name."
+  type        = string
+  default     = "ghcr.io/openfaas/gateway"
+}
+
+variable "queue_worker_image_name" {
+  description = "The faas queue worker docker image name."
+  type        = string
+  default     = "ghcr.io/openfaas/queue-worker"
+}
+
+variable "faasd_image_tag" {
+  type    = string
+  default = "0.13.0"
+}
+
+variable "nats_image_tag" {
+  type    = string
+  default = "0.22.0"
+}
+
+variable "auth_plugin_image_tag" {
+  type    = string
+  default = "0.21.0"
+}
+
+variable "gateway_image_tag" {
+  type    = string
+  default = "0.21.0"
+}
+
+variable "queue_worker_image_tag" {
+  type    = string
+  default = "0.12.2"
+}
+
+variable "faasd_provider_task_resources" {
+  description = "Resources used by faasd_provider task."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 50,
+    memory = 100,
+  }
+}
+
+variable "nats_task_resources" {
+  description = "Resources used by nats task."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 50,
+    memory = 50,
+  }
+}
+
+variable "basic_auth_task_resources" {
+  description = "Resources used by basic authentication task."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 20,
+    memory = 30,
+  }
+}
+
+variable "gateway_task_resources" {
+  description = "Resources used by gateway task."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 50,
+    memory = 50,
+  }
+}
+
+variable "queue_worker_task_resources" {
+  description = "Resources used by queue worker task."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 50,
+    memory = 50,
+  }
+}
+
+variable "register_auth_consul_service" {
+  description = "If you want to register a consul service for the basic authentication task."
+  type        = bool
+  default     = false
+}
+variable "register_nats_consul_service" {
+  description = "If you want to register a consul service for the nats task."
+  type        = bool
+  default     = false
+}
+variable "register_gateway_consul_service" {
+  description = "If you want to register a consul service for the gateway task."
+  type        = bool
+  default     = false
+}
+variable "register_monitoring_consul_service" {
+  description = "If you want to register a consul service for the monitoring task."
+  type        = bool
+  default     = false
+}
+variable "register_provider_consul_service" {
+  description = "If you want to register a consul service for the provider task."
+  type        = bool
+  default     = false
+}
+
+variable "basic_auth_consul_service_name" {
+  description = "The consul service name for the basic authentication task."
+  type        = string
+  default     = "basic-auth"
+}
+
+variable "provider_consul_service_name" {
+  description = "The consul service name for the provider task."
+  type        = string
+  default     = "faasd-provider"
+}
+
+variable "nats_consul_service_name" {
+  description = "The consul service name for the nats task."
+  type        = string
+  default     = "nats"
+}
+
+variable "gateway_consul_service_name" {
+  description = "The consul service name for the gateway task."
+  type        = string
+  default     = "gateway"
+}
+
+variable "faasd_monitoring_consul_service_name" {
+  description = "The consul service name for the monitoring task."
+  type        = string
+  default     = "faasd-monitoring"
+}
+
+variable "volume_name" {
+  description = "The name of the volume you want faasd to use."
+  type        = string
+}
+
+variable "volume_type" {
+  description = "The type of the volume you want faasd to use."
+  type        = string
+  default     = "host"
+}
+
+variable "docker_faasd_env_vars" {
+  type        = map(string)
+  description = "Environment variables to pass to Docker container."
+  default     = {}
+}
+
+

--- a/packs/faasd/vars.nomad
+++ b/packs/faasd/vars.nomad
@@ -1,0 +1,5 @@
+docker_faasd_env_vars = {
+  "java_opts": "-Dhudson.model.DownloadService.noSignatureCheck=true",
+}
+volume_name = "faasd-volume"
+register_consul_service = true

--- a/packs/faasd/vars.nomad
+++ b/packs/faasd/vars.nomad
@@ -1,5 +1,6 @@
-docker_faasd_env_vars = {
-  "java_opts": "-Dhudson.model.DownloadService.noSignatureCheck=true",
-}
-volume_name = "faasd-volume"
-register_consul_service = true
+register_auth_consul_service = true
+register_nats_consul_service = true
+register_gateway_consul_service = true
+register_monitoring_consul_service = true
+register_provider_consul_service = true
+dns_servers = ["192.168.105.151"]

--- a/packs/faasd/vars.nomad
+++ b/packs/faasd/vars.nomad
@@ -1,6 +1,5 @@
 register_auth_consul_service = true
 register_nats_consul_service = true
 register_gateway_consul_service = true
-register_monitoring_consul_service = true
 register_provider_consul_service = true
 dns_servers = ["192.168.105.151"]


### PR DESCRIPTION
This pack is for deploying Faasd (from Alex Ellis, [openfaas.com](https://www.openfaas.com/)) on Nomad.
It allows to deploy it with Consul registration or not. There is a `vars.nomad` file example that shows that you can also set dns server(s) for correct name resolving.
Let me know if you can see something to fix. It would be really appreciated!