### PR TITLE
Pack: AWS EFS CSI plugin

### DIFF
--- a/packs/aws_efs_csi/README.md
+++ b/packs/aws_efs_csi/README.md
@@ -18,7 +18,7 @@ be provided with access to AWS EFS through AWS IAM.
 
 ### `constraints` List of Objects
 
-[Nomad job specification constraints][job_constraint] allows restricting the set of eligible nodes
+[Nomad job specification constraints](https://www.nomadproject.io/docs/job-specification/constraint) allows restricting the set of eligible nodes
 on node task will run.
 
 - `attribute` (string) - Specifies the name or reference of the attribute to examine for the

--- a/packs/aws_efs_csi/README.md
+++ b/packs/aws_efs_csi/README.md
@@ -43,6 +43,11 @@ variable list of objects for the default configuration is shown below and uses a
     }
 ]
 ```
+Below is also an example of how to pass `constraints` to the CLI with with the -var argument.
+```bash
+nomad-pack run -var 'constraints=[{"attribute":"$${meta.my_custom_value}","operator":">","value":"3"}]' packs/aws_efs_csi
+```
+When setting the `constrains` variable manually its default value will be overriden.
 
 ### `resources` Object
 

--- a/packs/aws_efs_csi/README.md
+++ b/packs/aws_efs_csi/README.md
@@ -28,7 +28,7 @@ on node task will run.
   operation.
 
 By default the job will run on hosts running linux and having Docker privileged mode enabled. The HCL
-variable list of objects is shown below and uses a double dollar sign for escaping:
+variable list of objects for the default configuration is shown below and uses a double dollar sign for escaping:
 ```hcl
 [
     {

--- a/packs/aws_efs_csi/README.md
+++ b/packs/aws_efs_csi/README.md
@@ -13,7 +13,7 @@ be provided with access to AWS EFS through AWS IAM.
 - `region` (string "global") - The region where the job should be placed.
 - `constraints` (list(object)) - Constraints to apply to the entire job.
 - `resources` (object) - The resource to assign to the plugin task.
-- `image` (string "amazon/aws-efs-csi-driver:master") - The Docker image to run on the plugin tasks. 
+- `image` (string "amazon/aws-efs-csi-driver:master") - The Docker image to run on the plugin tasks.
 - `csi_id` (string "aws-efs") - The CSI ID to use for this plugin.
 
 ### `constraints` List of Objects
@@ -35,7 +35,7 @@ variable list of objects for the default configuration is shown below and uses a
       attribute = "$${attr.kernel.name}",
       value     = "linux",
       operator  = null,
-    }, 
+    },
     {
       attribute = "$${attr.driver.docker.privileged.enabled}",
       value     = true,
@@ -46,14 +46,14 @@ variable list of objects for the default configuration is shown below and uses a
 
 ### `resources` Object
 
--`cpu` (number 100) - Specifies the CPU required to run this task in MHz.
--`memory` (number 128) - Specifies the memory required in MB.
+- `cpu` (number 100) - Specifies the CPU required to run this task in MHz.
+- `memory` (number 128) - Specifies the memory required in MB.
 
 
 ## Volume creation example
-The plugin currently only by creating new access points to existing EFS file systems. So you'll first have 
-to provision a new EFS file system. The capacity in the volume spec is not used, but is required by the 
-CSI Volume API. 
+The plugin currently only by creating new access points to existing EFS file systems. So you'll first have
+to provision a new EFS file system. The capacity in the volume spec is not used, but is required by the
+CSI Volume API.
 
 #### **`volume.hcl`**
 ```hcl

--- a/packs/aws_efs_csi/README.md
+++ b/packs/aws_efs_csi/README.md
@@ -1,0 +1,84 @@
+# AWS EFS CSI plugin
+
+This pack contains a single system job that runs the AWS EFS CSI plugin. It will run the nodes in
+monolith modes, which means they will run as both nodes and controllers. The job can only be run
+on Nomad hosts which have enabled privileged mode for Docker. In addition the hosts will need to have to
+be provided with access to AWS EFS through AWS IAM.
+
+## Variables
+
+- `job_name` (string "aws-efs-csi-nodes") - The name to use as the job name.
+- `datacenters` (list(string) ["dc1"]) - A list of datacenters in the region which are eligible for
+  task placement.
+- `region` (string "global") - The region where the job should be placed.
+- `constraints` (list(object)) - Constraints to apply to the entire job.
+- `resources` (object) - The resource to assign to the plugin task.
+- `image` (string "amazon/aws-efs-csi-driver:master") - The Docker image to run on the plugin tasks. 
+- `csi_id` (string "aws-efs") - The CSI ID to use for this plugin.
+
+### `constraints` List of Objects
+
+[Nomad job specification constraints][job_constraint] allows restricting the set of eligible nodes
+on node task will run.
+
+- `attribute` (string) - Specifies the name or reference of the attribute to examine for the
+  constraint.
+- `operator` (string) - Specifies the comparison operator. The ordering is compared lexically.
+- `value` (string) - Specifies the value to compare the attribute against using the specified
+  operation.
+
+By default the job will run on hosts running linux and having Docker privileged mode enabled. The HCL
+variable list of objects is shown below and uses a double dollar sign for escaping:
+```hcl
+[
+    {
+      attribute = "$${attr.kernel.name}",
+      value     = "linux",
+      operator  = null,
+    }, 
+    {
+      attribute = "$${attr.driver.docker.privileged.enabled}",
+      value     = true,
+      operator  = null,
+    }
+]
+```
+
+### `resources` Object
+
+-`cpu` (number 100) - Specifies the CPU required to run this task in MHz.
+-`memory` (number 128) - Specifies the memory required in MB.
+
+
+## Volume creation example
+The plugin currently only by creating new access points to existing EFS file systems. So you'll first have 
+to provision a new EFS file system. The capacity in the volume spec is not used, but is required by the 
+CSI Volume API. 
+
+#### **`volume.hcl`**
+```hcl
+id = "test"
+name = "Test"
+type = "csi"
+plugin_id = "aws-efs"
+capacity_max = "1G"
+capacity_min = "1M"
+
+capability {
+	access_mode = "single-node-writer"
+	attachment_mode = "file-system"
+}
+
+parameters {
+	provisioningMode = "efs-ap"
+	fileSystemId = "<insert-your-efs-id>"
+	directoryPerms = "700"
+	gidRangeStart = "1000"
+	gidRangeEnd = "2000"
+	basePath = "/test"
+}
+```
+Run the command:
+```sh
+nomad volume create volume.hcl
+```

--- a/packs/aws_efs_csi/metadata.hcl
+++ b/packs/aws_efs_csi/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = "https://github.com/kubernetes-sigs/aws-efs-csi-driver"
+  author = "Kubernetes SIGs"
+}
+
+pack {
+  name        = "aws_efs_csi"
+  description = "Configures a set of nodes to run the AWS EFS CSI volume plugin."
+  url         = "https://github.com/hashicorp/nomad-pack-community-registry/tree/main/aws-efs-csi-driver"
+  version     = "0.0.1"
+}

--- a/packs/aws_efs_csi/outputs.tpl
+++ b/packs/aws_efs_csi/outputs.tpl
@@ -1,0 +1,1 @@
+AWS EFS CSI nodes successfully deployed.

--- a/packs/aws_efs_csi/templates/aws-efs-csi-nodes.nomad.tpl
+++ b/packs/aws_efs_csi/templates/aws-efs-csi-nodes.nomad.tpl
@@ -1,0 +1,41 @@
+job [[ .aws_efs_csi.job_name | quote]] {
+
+  region      = [[ .aws_efs_csi.region | quote]]
+  datacenters = [[ .aws_efs_csi.datacenters | toPrettyJson ]]
+  type        = "system"
+  [[ if .aws_efs_csi.constraints ]][[ range $idx, $constraint := .aws_efs_csi.constraints ]]
+  constraint {
+    attribute = [[ $constraint.attribute | quote ]]
+    [[- if $constraint.value ]]
+    value     = [[ $constraint.value | quote ]]
+    [[- end ]]
+    [[- if $constraint.operator  ]]
+    operator  = [[ $constraint.operator | quote ]]
+    [[- end ]]
+  }
+  [[- end ]][[- end ]]
+
+  group "nodes" {
+    task "plugin" {
+			driver = "docker"
+			config {
+				image = "[[ .aws_efs_csi.image ]]"
+				args = [
+					"--endpoint=unix://csi/csi.sock",
+					"--logtostderr",
+					"--v=2",
+				]
+				privileged = true
+			}
+			csi_plugin {
+				id        = [[ .aws_efs_csi.csi_id | quote]]
+				type      = "monolith"
+				mount_dir = "/csi"
+			}
+      resources {
+        cpu    = [[ .aws_efs_csi.resources.cpu ]]
+        memory = [[ .aws_efs_csi.resources.memory ]]
+      }
+    }
+  }
+}

--- a/packs/aws_efs_csi/variables.hcl
+++ b/packs/aws_efs_csi/variables.hcl
@@ -1,0 +1,63 @@
+variable "job_name" {
+  description = "The name to use as the job name for the plugins nodes."
+  type        = string
+  default     = "aws-efs-csi-nodes"
+}
+
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement."
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "region" {
+  description = "The region where the job should be placed."
+  type        = string
+  default     = "global"
+}
+
+variable "image" {
+  description = "Docker image to run on the nodes."
+  type        = string
+  default     = "amazon/aws-efs-csi-driver:master"
+}
+
+variable "constraints" {
+  description = "Constraints to apply to the entire job."
+  type        = list(object({
+    attribute = string
+    operator  = string
+    value     = string
+  }))
+  default = [
+    {
+      attribute = "$${attr.kernel.name}",
+      value     = "linux",
+      operator  = null,
+    }, 
+    {
+      attribute = "$${attr.driver.docker.privileged.enabled}",
+      value     = true,
+      operator  = null,
+    }
+  ]
+}
+
+variable "resources" {
+  description = "The resources to allocate for the plugins tasks."
+  type        = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 100,
+    memory = 128,
+  }
+}
+
+variable "csi_id" {
+  description = "ID to assign to the CSI plugin"
+  type = string
+  default = "aws-efs"
+}


### PR DESCRIPTION
Here is a pack to setup the AWS EFS CSI plugin running as a system job.

The job will only run on Nomad hosts with Docker privileged mode enabled and will need an IAM policy to allow the use 
of the EFS API. The plugin runs in monolith mode so that new volumes can be created dynamically. 