### PR TITLE
Pack: CTFd

### DIFF
--- a/packs/ctfd/README.md
+++ b/packs/ctfd/README.md
@@ -1,0 +1,60 @@
+# CTFd
+
+This pack contains all you need to deploy CTFd in Nomad. It uses the Docker driver and spins up these services:
+
+| Service | Default version |
+| ------- | --------------- |
+| CTFd | 3.3.1 |
+| MariaDB | 10 |
+| Redis | 6 |
+
+## Dependencies
+
+This pack requires the Docker driver to be enabled and R/W access to the following pre-existing volumes, the names and types of which can be specified through the pack's variables:
+
+| Volume's variable name | Description |
+| ---------------------- | ----------- |
+| `uploads_volume_name` | Where to store files uploaded through CTFd (ex.: challenges' attachments). |
+| `mariadb_volume_name` | MariaDB data storage. |
+| `redis_volume_name` | Redis data and periodic backup storage. |
+
+## Variables
+
+| Name | Type | Default value | Description |
+| ---- | ---- | ------------- | ----------- |
+| `job_name` | _string_ | "ctfd" | The name to use as the job name which overrides using the pack name. |
+| `region` | _string_ | "" | The region where jobs will be deployed. |
+| `datacenters` | _list("string")_ | ["dc1"] | A list of datacenters in the region which are eligible for task placement. |
+| `namespace` | _string_ | _N/A_ | The namespace where the job should be placed. |
+| `register_consul_service` | _bool_ | "False" | If you want to register a Consul service for the job. |
+| `consul_service_name` | _string_ | "ctfd" | The consul service name for the application. |
+| `consul_service_tags` | _list("string")_ | ["ctfd"] | The consul service tags for the application. |
+| `uploads_volume_name` | _string_ | "ctfd_uploads" | The name of the dedicated data volume you want CTFd to store file uploads into. |
+| `uploads_volume_type` | _string_ | "host" | The type of the dedicated data volume you want CTFd to store file uploads into. |
+| `mariadb_volume_name` | _string_ | "ctfd_mariadb" | The name of the dedicated data volume you want MariaDB to store data into. |
+| `mariadb_volume_type` | _string_ | "host" | The type of the dedicated data volume you want MariaDB to store data into. |
+| `redis_volume_name` | _string_ | "ctfd_redis" | The name of the dedicated data volume you want Redis to store data into. |
+| `redis_volume_type` | _string_ | "host" | The type of the dedicated data volume you want Redis to store data into. |
+| `ctfd_resources` | _object({cpu:"number",memory:"number"})_ | {cpu: 250, memory: 500} | The resources reserved for CTFd itself. |
+| `ctfd_image_name` | _string_ | "ctfd/ctfd" | The CTFd Docker image name to pull. |
+| `ctfd_image_tag` | _string_ | "3.3.1-release" | The CTFd Docker image tag to pull. |
+| `ctfd_port` | _number_ | _N/A_ | The static host port that CTFd will be served on. If not specified, an external reverse proxy will be needed. |
+| `ctfd_expect_reverse_proxy` | _bool_ | "False" | If you want CTFd to expect being behind a reverse proxy. |
+| `mariadb_resources` | _object({cpu:"number",memory:"number"})_ | {cpu: 250, memory: 500} | The resources reserved for MariaDB. |
+| `mariadb_image_name` | _string_ | "mariadb" | The MariaDB Docker image name to pull. |
+| `mariadb_image_tag` | _string_ | "10" | The MariaDB Docker image tag to pull. |
+| `mariadb_root_password` | _string_ | "ctfd" | The password that will be used for the 'root' MariaDB user. |
+| `mariadb_ctfd_password` | _string_ | "ctfd" | The password that will be used to create the 'ctfd' MariaDB user. |
+| `redis_resources` | _object({cpu:"number",memory:"number"})_ | {cpu: 250, memory: 500} | The resources reserved for Redis. |
+| `redis_image_name` | _string_ | "redis" | The Redis Docker image name to pull. |
+| `redis_image_tag` | _string_ | "6" | The Redis Docker image tag to pull. |
+
+## Example run
+
+> `nomad-pack run . --var=datacenters='["dc1"]' --var ctfd_port=8888`
+
+Note: the contents of the host volumes aren't erased, if the deployment fails double check that they don't contain old/invalid data.
+
+## Initial setup
+
+Refer to CTFd's official [Getting started](https://docs.ctfd.io/tutorials/getting-started/) docs for guidance once the stack is running.

--- a/packs/ctfd/README.md
+++ b/packs/ctfd/README.md
@@ -18,6 +18,8 @@ This pack requires the Docker driver to be enabled and R/W access to the followi
 | `mariadb_volume_name` | MariaDB data storage. |
 | `redis_volume_name` | Redis data and periodic backup storage. |
 
+It also relies on an existing Consul integration for health checking and service discovery.
+
 ## Variables
 
 | Name | Type | Default value | Description |

--- a/packs/ctfd/metadata.hcl
+++ b/packs/ctfd/metadata.hcl
@@ -1,6 +1,6 @@
 app {
   url    = "https://ctfd.io/"
-  author = "nmaggioni"
+  author = "CTFd"
 }
 
 pack {

--- a/packs/ctfd/metadata.hcl
+++ b/packs/ctfd/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = "https://ctfd.io/"
+  author = "nmaggioni"
+}
+
+pack {
+  name        = "ctfd"
+  description = "The open source Capture The Flag framework for hiring, training, and teaching hackers"
+  url         = "https://github.com/hashicorp/nomad-pack-community-registry/ctfd"
+  version     = "0.0.1"
+}

--- a/packs/ctfd/outputs.tpl
+++ b/packs/ctfd/outputs.tpl
@@ -1,0 +1,4 @@
+Congrats on deploying CTFd.
+
+Check the official documentation to get started:
+https://docs.ctfd.io/tutorials/getting-started/

--- a/packs/ctfd/templates/_helpers.tpl
+++ b/packs/ctfd/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+// allow nomad-pack to set the job name
+
+[[- define "job_name" -]]
+[[- if eq .ctfd.job_name "" -]]
+[[- .nomad_pack.pack.name | quote -]]
+[[- else -]]
+[[- .ctfd.job_name | quote -]]
+[[- end -]]
+[[- end -]]
+
+// only deploys to a region if specified
+
+[[- define "region" -]]
+[[- if not (eq .ctfd.region "") -]]
+region = [[ .ctfd.region | quote]]
+[[- end -]]
+[[- end -]]

--- a/packs/ctfd/templates/ctfd.nomad.tpl
+++ b/packs/ctfd/templates/ctfd.nomad.tpl
@@ -11,6 +11,11 @@ job [[ template "job_name" . ]] {
     value     = "true",
   }
 
+  constraint {
+    attribute = "${attr.consul.version}"
+    operator  = "is_set"
+  }
+
   group [[ template "job_name" . ]] {
     count = 1
 

--- a/packs/ctfd/templates/ctfd.nomad.tpl
+++ b/packs/ctfd/templates/ctfd.nomad.tpl
@@ -1,0 +1,228 @@
+job [[ template "job_name" . ]] {
+  [[ template "region" . ]]
+  datacenters = [[ .ctfd.datacenters | toPrettyJson ]]
+  [[- if .ctfd.namespace ]]
+  namespace   = [[ .ctfd.namespace | quote ]]
+  [[- end ]]
+  type = "service"
+
+  constraint {
+    attribute = "${attr.driver.docker.volumes.enabled}",
+    value     = "true",
+  }
+
+  group [[ template "job_name" . ]] {
+    count = 1
+
+    network {
+      port "ctfd" {
+        [[- if .ctfd.ctfd_port ]]
+        static = [[- .ctfd.ctfd_port ]]
+        [[- end ]]
+        to = 8000
+      }
+      port "mariadb" {
+        to = 3306
+      }
+      port "redis" {
+        to = 6379
+      }
+    }
+
+    [[- if .ctfd.register_consul_service ]]
+    service {
+      name = "[[ .ctfd.consul_service_name ]]"
+      [[- if ne (len .ctfd.consul_service_tags) 0 ]]
+      tags = [[ .ctfd.consul_service_tags | toPrettyJson ]]
+      [[- end ]]
+      port = "http"
+
+      check {
+        type     = "http"
+        port     = "ctfd"
+        path     = "/"
+        interval = "10s"
+        timeout  = "5s"
+      }
+    }
+    [[- end ]]
+
+    task "ctfd" {
+      driver = "docker"
+
+      service {
+        name = "[[ .ctfd.job_name ]]-ctfd"
+        port = "ctfd"
+
+        tags = [[ .ctfd.consul_service_tags | toPrettyJson ]]
+
+        check {
+          type = "http"
+          port = "ctfd"
+          path = "/"
+          interval = "10s"
+          timeout  = "5s"
+
+          check_restart {
+            limit = 3
+            grace = "30s"
+          }
+        }
+      }
+
+      restart {
+        attempts = 3
+        interval = "15m"
+        delay = "30s"
+        mode = "fail"
+      }
+
+      env {
+        UPLOAD_FOLDER = "/var/uploads"
+        DATABASE_URL = "mysql+pymysql://ctfd:[[ .ctfd.mariadb_ctfd_password ]]@[[ .ctfd.job_name ]]-db.service.consul:${NOMAD_HOST_PORT_mariadb}/ctfd"
+        REDIS_URL = "redis://[[ .ctfd.job_name ]]-cache.service.consul:${NOMAD_HOST_PORT_redis}"
+        WORKERS = "1"
+        LOG_FOLDER = "${NOMAD_ALLOC_DIR}/logs/ctfd"
+        ACCESS_LOG = "${NOMAD_ALLOC_DIR}/logs/gunicorn.access"
+        ERROR_LOG = "${NOMAD_ALLOC_DIR}/logs/gunicorn.error"
+        [[- if .ctfd.ctfd_expect_reverse_proxy ]]
+        REVERSE_PROXY = "true"
+        [[- end]]
+        FLASK_ENV = "production"
+      }
+
+      config {
+        image = "[[ .ctfd.ctfd_image_name ]]:[[ .ctfd.ctfd_image_tag ]]"
+        ports = ["ctfd"]
+      }
+
+      resources {
+        cpu = [[ .ctfd.ctfd_resources.cpu ]]
+        memory = [[ .ctfd.ctfd_resources.memory ]]
+      }
+
+      volume_mount {
+        volume = "[[ .ctfd.uploads_volume_name ]]"
+        destination = "/var/uploads"
+      }
+    }
+
+    task "db" {
+      driver = "docker"
+
+      lifecycle {
+        hook = "prestart"
+        sidecar = true
+      }
+
+      service {
+        name = "[[ .ctfd.job_name ]]-db"
+        port = "mariadb"
+
+        tags = [[ .ctfd.consul_service_tags | toPrettyJson ]]
+
+        check {
+          type = "tcp"
+          port = "mariadb"
+          interval = "10s"
+          timeout  = "5s"
+
+          check_restart {
+            limit = 3
+            grace = "30s"
+          }
+        }
+      }
+
+      env {
+        MYSQL_ROOT_PASSWORD = "[[ .ctfd.mariadb_root_password ]]"
+        MYSQL_USER = "ctfd"
+        MYSQL_PASSWORD = "[[ .ctfd.mariadb_ctfd_password ]]"
+        MYSQL_DATABASE = "ctfd"
+      }
+
+      config {
+        image = "[[ .ctfd.mariadb_image_name ]]:[[ .ctfd.mariadb_image_tag ]]"
+        command = "mysqld"
+        args = [
+          "--character-set-server=utf8mb4",
+          "--collation-server=utf8mb4_unicode_ci",
+          "--wait_timeout=28800",
+          "--log-warnings=0"
+        ]
+        ports = ["mariadb"]
+      }
+
+      resources {
+        cpu = [[ .ctfd.mariadb_resources.cpu ]]
+        memory = [[ .ctfd.mariadb_resources.memory ]]
+      }
+
+      volume_mount {
+        volume = "[[ .ctfd.mariadb_volume_name ]]"
+        destination = "/var/lib/mysql"
+      }
+    }
+
+    task "cache" {
+      driver = "docker"
+
+      lifecycle {
+        hook = "prestart"
+        sidecar = true
+      }
+
+      service {
+        name = "[[ .ctfd.job_name ]]-cache"
+        port = "redis"
+
+        tags = [[ .ctfd.consul_service_tags | toPrettyJson ]]
+
+        check {
+          type = "tcp"
+          port = "redis"
+          interval = "10s"
+          timeout  = "5s"
+
+          check_restart {
+            limit = 3
+            grace = "30s"
+          }
+        }
+      }
+
+      config {
+        image = "[[ .ctfd.redis_image_name ]]:[[ .ctfd.redis_image_tag ]]"
+        ports = ["redis"]
+      }
+
+      resources {
+        cpu = [[ .ctfd.redis_resources.cpu ]]
+        memory = [[ .ctfd.redis_resources.memory ]]
+      }
+
+      volume_mount {
+        volume = "[[ .ctfd.redis_volume_name ]]"
+        destination = "/data"
+      }
+    }
+
+    volume "[[ .ctfd.uploads_volume_name ]]" {
+      type      = "[[ .ctfd.uploads_volume_type ]]"
+      read_only = false
+      source    = "[[ .ctfd.uploads_volume_name ]]"
+    }
+
+    volume "[[ .ctfd.mariadb_volume_name ]]" {
+      type      = "[[ .ctfd.mariadb_volume_type ]]"
+      read_only = false
+      source    = "[[ .ctfd.mariadb_volume_name ]]"
+    }
+
+    volume "[[ .ctfd.redis_volume_name ]]" {
+      type      = "[[ .ctfd.redis_volume_type ]]"
+      read_only = false
+      source    = "[[ .ctfd.redis_volume_name ]]"
+    }
+  }
+}

--- a/packs/ctfd/variables.hcl
+++ b/packs/ctfd/variables.hcl
@@ -1,0 +1,172 @@
+variable "job_name" {
+  description = "The name to use as the job name which overrides using the pack name."
+  type        = string
+  // If "", the pack name will be used
+  default = "ctfd"
+}
+
+variable "region" {
+  description = "The region where jobs will be deployed."
+  type        = string
+  default     = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement."
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "namespace" {
+  description = "The namespace where the job should be placed."
+  type        = string
+}
+
+variable "register_consul_service" {
+  description = "If you want to register a Consul service for the job."
+  type        = bool
+  default     = false
+}
+
+variable "consul_service_name" {
+  description = "The consul service name for the application."
+  type        = string
+  default     = "ctfd"
+}
+
+variable "consul_service_tags" {
+  description = "The consul service tags for the application."
+  type        = list(string)
+  default     = ["ctfd"]
+}
+
+variable "uploads_volume_name" {
+  description = "The name of the dedicated data volume you want CTFd to store file uploads into."
+  type        = string
+  default     = "ctfd_uploads"
+}
+
+variable "uploads_volume_type" {
+  description = "The type of the dedicated data volume you want CTFd to store file uploads into."
+  type        = string
+  default     = "host"
+}
+
+variable "mariadb_volume_name" {
+  description = "The name of the dedicated data volume you want MariaDB to store data into."
+  type        = string
+  default     = "ctfd_mariadb"
+}
+
+variable "mariadb_volume_type" {
+  description = "The type of the dedicated data volume you want MariaDB to store data into."
+  type        = string
+  default     = "host"
+}
+
+variable "redis_volume_name" {
+  description = "The name of the dedicated data volume you want Redis to store data into."
+  type        = string
+  default     = "ctfd_redis"
+}
+
+variable "redis_volume_type" {
+  description = "The type of the dedicated data volume you want Redis to store data into."
+  type        = string
+  default     = "host"
+}
+
+variable "ctfd_resources" {
+  description = "The resources reserved for CTFd itself."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 250,
+    memory = 500,
+  }
+}
+
+variable "ctfd_image_name" {
+  description = "The CTFd Docker image name to pull."
+  type        = string
+  default     = "ctfd/ctfd"
+}
+
+variable "ctfd_image_tag" {
+  description = "The CTFd Docker image tag to pull."
+  type        = string
+  default     = "3.3.1-release"
+}
+
+variable "ctfd_port" {
+  description = "The static host port that CTFd will be served on. If not specified, an external reverse proxy will be needed."
+  type        = number
+}
+
+variable "ctfd_expect_reverse_proxy" {
+  description = "If you want CTFd to expect being behind a reverse proxy."
+  type        = bool
+  default     = false
+}
+
+variable "mariadb_resources" {
+  description = "The resources reserved for MariaDB."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 250,
+    memory = 500,
+  }
+}
+
+variable "mariadb_image_name" {
+  description = "The MariaDB Docker image name to pull."
+  type        = string
+  default     = "mariadb"
+}
+
+variable "mariadb_image_tag" {
+  description = "The MariaDB Docker image tag to pull."
+  type        = string
+  default     = "10"
+}
+
+variable "mariadb_root_password" {
+  description = "The password that will be used for the 'root' MariaDB user."
+  type        = string
+  default     = "ctfd"
+}
+
+variable "mariadb_ctfd_password" {
+  description = "The password that will be used to create the 'ctfd' MariaDB user."
+  type        = string
+  default     = "ctfd"
+}
+
+variable "redis_resources" {
+  description = "The resources reserved for Redis."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 250,
+    memory = 500,
+  }
+}
+
+variable "redis_image_name" {
+  description = "The Redis Docker image name to pull."
+  type        = string
+  default     = "redis"
+}
+
+variable "redis_image_tag" {
+  description = "The Redis Docker image tag to pull."
+  type        = string
+  default     = "6"
+}


### PR DESCRIPTION
Here's a pack to run [**CTFd**](https://ctfd.io/) and host [CTF competitions](https://ctftime.org/ctf-wtf/) or, more generally, Cyber Security training events. It is derived from a private setup that has been battle-tested in a regional public CTF event not long ago.

+ **Drivers and requirements:** Docker driver, access to Docker volumes, existing r/w volumes, Consul.
+ **What's included:** CTFd, MariaDB, Redis; preconfigured as much as possible and including health checks and appropriate inter-dependency hooks.
+ **What's not included:** a reverse proxy for SSL termination in front of CTFd. A generic template would need to be radically altered for each setup and it's trivial to add manually when not already present elsewhere in the stack.

This pack lets operators spin up an event-ready CTFd instance in a matter of minutes, and in order to customize CTFd with themes and plugins it is only needed to add them to your own Docker image and change the relative value in the pack's variables.

The README should already cover the requirements and each possible change to the config, but please let me know if something needs to be described in greater detail or is missing.