### PR TITLE
rabbitmq: add tls cluster pack

### DIFF
--- a/packs/rabbitmq/README.md
+++ b/packs/rabbitmq/README.md
@@ -1,0 +1,38 @@
+# RabbitMQ Secure Cluster
+
+This pack contains a RabbitMQ cluster, configured to use TLS (by default, using certificates from Vault).
+
+It has a requirement of Consul being available, as it is used for clustering/node discovery.
+
+This pack makes use of two files stored in the Task's local volume; `rabbitmq.conf` and `enabled_plugins`.  There shouldn't be any need to touch these files directly, as you can modify both through the variables `extra_conf` and `enabled_plugins` respectively.
+
+## Configuration
+
+| Name | Required | Default | Comments |
+|------|----------|---------|----------|
+| `job_name` | no | `"rabbit"` | Override the Nomad job name |
+| `datacenters` | no | `"dc1"` |  |
+| `cluster_size` | no | `3` | This should be an odd number |
+| `consul_service_amqp_tags` | no | `["amqp"]` |
+| `consul_service_management_tags` | no | `["management"]` |
+| `vault_enabled` | no | `true` |
+| `vault_roles` | no | `["rabbit"]` |
+| `image` | no | `"rabbitmq:3.9.10-management-alpine"`  |
+| `enabled_plugins` |  no | `["rabbitmq_management"]` | The `rabbitmq_peer_discovery_consul` is always enabled, as it is required for clustering. |
+| `extra_conf` | no | `""` | Any extra configuration for the `rabbitmq.conf` file. See [Configuration](https://www.rabbitmq.com/configure.html) |
+| `port_amqp` | no | `0` | Setting to `0` causes a random port to be assigned.  `5671` is the default port RabbitMQ uses. |
+| `port_ui` | no | `0` | Setting to `0` causes a random port to be assigned |
+| `pki_vault_enabled` | no | `true`  |
+| `pki_vault_domain` | yes | `""`  | e.g. `nomad.company.internal` |
+| `pki_vault_secret_path` | no |  `"pki/issue/rabbit"` |
+| `pki_artifact_ca_cert` | no | `{}` | Only used if `pki_vault_enabled=false`. See [Artifact Stanza](https://www.nomadproject.io/docs/job-specification/artifact) for fields. |
+| `pki_artifact_node_cert` | no | `{}` | Only used if `pki_vault_enabled=false`. See [Artifact Stanza](https://www.nomadproject.io/docs/job-specification/artifact) for fields. |
+| `pki_artifact_node_cert_key` | no |  `{}` | Only used if `pki_vault_enabled=false`. See [Artifact Stanza](https://www.nomadproject.io/docs/job-specification/artifact) for fields. |
+| `cookie_vault` | no | `{}` |
+| `cookie_static` | no | `""` |
+| `admin_user_vault_enabled` | no | `true` | |
+| `admin_user_vault_path` | no | `"secret/data/rabbit/admin"` | |
+| `admin_user_vault_username_key` | no | `"username"` | |
+| `admin_user_vault_password_key` | no | `"password"` | |
+| `admin_user_static_username` | no | `""`  | Only used if `admin_user_vault_enabled=false` |
+| `admin_user_static_password` | no | `""`  | Only used if `admin_user_vault_enabled=false` |

--- a/packs/rabbitmq/README.md
+++ b/packs/rabbitmq/README.md
@@ -22,6 +22,8 @@ This pack makes use of two files stored in the Task's local volume; `rabbitmq.co
 | `extra_conf` | no | `""` | Any extra configuration for the `rabbitmq.conf` file. See [Configuration](https://www.rabbitmq.com/configure.html) |
 | `port_amqp` | no | `0` | Setting to `0` causes a random port to be assigned.  `5671` is the default port RabbitMQ uses. |
 | `port_ui` | no | `0` | Setting to `0` causes a random port to be assigned |
+| `port_discovery` | no | `4369` | The port RabbitMQ uses for node discovery.  Cannot be dynamically assigned. |
+| `port_clustering` | no | `25672` | The port RabbitMQ uses for clustering.  Cannot be dynamically assigned. |
 | `pki_vault_enabled` | no | `true`  |
 | `pki_vault_domain` | yes | `""`  | e.g. `nomad.company.internal` |
 | `pki_vault_secret_path` | no |  `"pki/issue/rabbit"` |

--- a/packs/rabbitmq/metadata.hcl
+++ b/packs/rabbitmq/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = "https://www.rabbitmq.com"
+  author = "VMWare"
+}
+
+pack {
+  name        = "rabbitmq"
+  description = "A RabbitMQ Cluster"
+  url         = "https://github.com/hashicorp/nomad-pack-community-registry/rabbitmq"
+  version     = "0.0.1"
+}

--- a/packs/rabbitmq/outputs.tpl
+++ b/packs/rabbitmq/outputs.tpl
@@ -1,0 +1,2 @@
+RabbitMQ successfully deployed.
+Services have been registered into consul.

--- a/packs/rabbitmq/templates/_consulservices.tpl
+++ b/packs/rabbitmq/templates/_consulservices.tpl
@@ -1,0 +1,13 @@
+[[- define "consul_services" -]]
+      service {
+        name = "rabbitmq"
+        port = "amqp"
+        tags = [[ .consul_service_amqp_tags | toJson ]]
+      }
+
+      service {
+        name = "rabbitmq"
+        port = "ui"
+        tags = [[ .consul_service_management_tags | toJson ]]
+      }
+[[- end -]]

--- a/packs/rabbitmq/templates/_helpers.tpl
+++ b/packs/rabbitmq/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+// allow nomad-pack to set the job name
+
+[[- define "job_name" -]]
+[[- if eq .rabbitmq.job_name "" -]]
+[[- .nomad_pack.pack.name | quote -]]
+[[- else -]]
+[[- .rabbitmq.job_name | quote -]]
+[[- end -]]
+[[- end -]]
+
+
+// if additional plugins are defined, return this:
+//    "[rabbitmq_peer_discovery_consul,rabbitmq_management]."
+// if nothing is defined, return only consul:
+//    "[rabbitmq_peer_discovery_consul]."
+[[- define "rabbit_plugins" ]]
+  [[- if .enabled_plugins -]]
+    "[rabbitmq_peer_discovery_consul,
+    [[- range $index, $name := .enabled_plugins -]]
+      [[if $index]],[[end]][[ $name ]]
+    [[- end -]]
+    ]."
+  [[- else -]]
+    "[rabbitmq_peer_discovery_consul]."
+  [[- end -]]
+[[- end -]]
+
+
+[[- define "port" ]]
+  [[- if . ]]
+        static = [[ . ]]
+  [[- end -]]
+[[- end -]]

--- a/packs/rabbitmq/templates/_pki.tpl
+++ b/packs/rabbitmq/templates/_pki.tpl
@@ -1,0 +1,83 @@
+[[- define "pki" -]]
+  [[- if and .vault_enabled .pki_vault_enabled ]]
+    [[- template "_pki_vault" . ]]
+  [[- else ]]
+    [[- template "_pki_artifact" . ]]
+  [[- end ]]
+[[- end -]]
+
+[[- define "_pki_vault" -]]
+      template {
+        data        = <<EOH
+        {{- $host := printf "common_name=%s.[[ .pki_vault_domain ]]" (env "attr.unique.hostname") -}}
+        {{- with secret [[ .pki_vault_secret_path | quote ]] $host -}}
+        {{- .Data.issuing_ca -}}
+        {{ end }}
+        EOH
+        destination = "${NOMAD_SECRETS_DIR}/ca.crt"
+        change_mode = "restart"
+      }
+
+      template {
+        data        = <<EOH
+        {{- $host := printf "common_name=%s.[[ .pki_vault_domain ]]" (env "attr.unique.hostname") -}}
+        {{ with secret [[ .pki_vault_secret_path | quote ]] $host -}}
+        {{- .Data.certificate -}}
+        {{ end }}
+        EOH
+        destination = "${NOMAD_SECRETS_DIR}/rabbit.crt"
+        change_mode = "restart"
+      }
+
+      template {
+        data        = <<EOH
+        {{- $host := printf "common_name=%s.[[ .pki_vault_domain ]]" (env "attr.unique.hostname") -}}
+        {{ with secret [[ .pki_vault_secret_path | quote ]] $host -}}
+        {{- .Data.private_key -}}
+        {{ end }}
+        EOH
+        destination = "${NOMAD_SECRETS_DIR}/rabbit.key"
+        change_mode = "restart"
+      }
+[[- end -]]
+
+[[- define "_pki_artifact" ]]
+  [[- if .pki_artifact_ca_cert.enabled ]]
+      artifact {
+        source      = [[ .pki_artifact_ca_cert.source | quote ]]
+        destination = "${NOMAD_SECRETS_DIR}/ca.crt"
+        [[- if .pki_artifact_ca_cert.headers ]]
+        headers     = [[ .pki_artifact_ca_cert.headers | toPrettyJson ]]
+        [[- end ]]
+        [[- if .pki_artifact_ca_cert.headers ]]
+        options     = [[ .pki_artifact_ca_cert.options | toPrettyJson ]]
+        [[- end ]]
+      }
+  [[- end -]]
+
+  [[- if .pki_artifact_node_cert.enabled ]]
+      artifact {
+        source      = [[ .pki_artifact_node_cert.source | quote ]]
+        destination = "${NOMAD_SECRETS_DIR}/rabbit.crt"
+        [[- if .pki_artifact_node_cert.headers ]]
+        headers     = [[ .pki_artifact_node_cert.headers | toPrettyJson ]]
+        [[- end ]]
+        [[- if .pki_artifact_node_cert.headers ]]
+        options     = [[ .pki_artifact_node_cert.options | toPrettyJson ]]
+        [[- end ]]
+      }
+  [[- end -]]
+
+  [[- if .pki_artifact_node_cert_key.enabled ]]
+      artifact {
+        source      = [[ .pki_artifact_node_cert_key.source | quote ]]
+        destination = "${NOMAD_SECRETS_DIR}/rabbit.key"
+        [[- if .pki_artifact_node_cert_key.headers ]]
+        headers     = [[ .pki_artifact_node_cert_key.headers | toPrettyJson ]]
+        [[- end ]]
+        [[- if .pki_artifact_node_cert_key.headers ]]
+        options     = [[ .pki_artifact_node_cert_key.options | toPrettyJson ]]
+        [[- end ]]
+      }
+  [[- end -]]
+[[- end -]]

--- a/packs/rabbitmq/templates/_rabbitenv.tpl
+++ b/packs/rabbitmq/templates/_rabbitenv.tpl
@@ -1,0 +1,44 @@
+
+[[- define "rabbit_env" -]]
+      template {
+        data        = <<EOH
+        [[- if .cookie_vault.enabled ]]
+          [[- template "_cookie_vault" .cookie_vault ]]
+        [[- else ]]
+          [[- template "_cookie_static" .cookie_static ]]
+        [[- end ]]
+
+        [[- if .admin_user_vault_enabled ]]
+          [[- template "_admin_vault" . ]]
+        [[- else]]
+          [[- template "_admin_static" . ]]
+        [[- end ]]
+        EOH
+        destination = "${NOMAD_SECRETS_DIR}/rabbit.env"
+        env         = true
+      }
+[[- end -]]
+
+
+[[- define "_cookie_vault" ]]
+        {{ with secret [[ .path | quote ]] }}
+        RABBITMQ_ERLANG_COOKIE="{{ .Data.data.[[ .key ]] }}"
+        {{ end }}
+[[- end -]]
+
+[[- define "_cookie_static" ]]
+        RABBITMQ_ERLANG_COOKIE=[[ . | quote ]]
+[[- end -]]
+
+
+[[- define "_admin_vault" ]]
+        {{ with secret [[ .admin_user_vault_path | quote ]] }}
+        RABBITMQ_DEFAULT_USER={{ .Data.data.[[ .admin_user_vault_username_key ]] }}
+        RABBITMQ_DEFAULT_PASS={{ .Data.data.[[ .admin_user_vault_password_key]] }}
+        {{ end }}
+[[- end -]]
+
+[[- define "_admin_static" ]]
+        RABBITMQ_DEFAULT_USER=[[ .admin_user_static_username | quote ]]
+        RABBITMQ_DEFAULT_PASS=[[ .admin_user_static_password | quote ]]
+[[- end -]]

--- a/packs/rabbitmq/templates/rabbit.nomad.tpl
+++ b/packs/rabbitmq/templates/rabbit.nomad.tpl
@@ -32,12 +32,12 @@ job [[ template "job_name" . ]] {
         [[- template "port" .rabbitmq.port_ui ]]
       }
       port "discovery" {
-        to = 4369
-        static = 4369
+        to     = [[ .rabbitmq.port_discovery ]]
+        static = [[ .rabbitmq.port_discovery ]]
       }
       port "clustering" {
-        to = 25672
-        static = 25672
+        to     = [[ .rabbitmq.port_clustering ]]
+        static = [[ .rabbitmq.port_clustering ]]
       }
     }
 
@@ -63,9 +63,11 @@ job [[ template "job_name" . ]] {
       }
 
       env {
-        CONSUL_HOST     = "${attr.unique.network.ip-address}"
-        CONSUL_SVC_PORT = "${NOMAD_HOST_PORT_amqp}"
-        CONSUL_SVC_TAGS = "amqp"
+        CONSUL_HOST        = "${attr.unique.network.ip-address}"
+        CONSUL_SVC_PORT    = "${NOMAD_HOST_PORT_amqp}"
+        CONSUL_SVC_TAGS    = "amqp"
+        ERL_EPMD_PORT      = "[[ .rabbitmq.port_discovery ]]"
+        RABBITMQ_DIST_PORT = "[[ .rabbitmq.port_clustering ]]"
       }
 
       template {

--- a/packs/rabbitmq/templates/rabbit.nomad.tpl
+++ b/packs/rabbitmq/templates/rabbit.nomad.tpl
@@ -1,0 +1,107 @@
+job [[ template "job_name" . ]] {
+
+  datacenters = [[ .rabbitmq.datacenters | toJson ]]
+  type        = "service"
+
+  constraint {
+    attribute = "${attr.consul.version}"
+    operator  = "is_set"
+  }
+
+  group "cluster" {
+    count = [[ .rabbitmq.cluster_size ]]
+
+    update {
+      max_parallel = 1
+    }
+
+    migrate {
+      max_parallel     = 1
+      health_check     = "checks"
+      min_healthy_time = "5s"
+      healthy_deadline = "30s"
+    }
+
+    network {
+      port "amqp" {
+        to = 5671
+        [[- template "port" .rabbitmq.port_amqp ]]
+      }
+      port "ui" {
+        to     = 15671
+        [[- template "port" .rabbitmq.port_ui ]]
+      }
+      port "discovery" {
+        to = 4369
+        static = 4369
+      }
+      port "clustering" {
+        to = 25672
+        static = 25672
+      }
+    }
+
+    task "rabbit" {
+      driver = "docker"
+
+      [[ if .rabbitmq.vault_enabled -]]
+      vault {
+        policies    = [[ .rabbitmq.vault_roles | toJson ]]
+        change_mode = "restart"
+      }
+      [[- end ]]
+
+      config {
+        image      = "[[ .rabbitmq.image ]]"
+        hostname   = "${attr.unique.hostname}"
+        ports      = ["amqp", "ui", "discovery", "clustering"]
+
+        volumes = [
+          "local/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf",
+          "local/enabled_plugins:/etc/rabbitmq/enabled_plugins"
+        ]
+      }
+
+      env {
+        CONSUL_HOST     = "${attr.unique.network.ip-address}"
+        CONSUL_SVC_PORT = "${NOMAD_HOST_PORT_amqp}"
+        CONSUL_SVC_TAGS = "amqp"
+      }
+
+      template {
+        data        = [[ template "rabbit_plugins" .rabbitmq ]]
+        destination = "local/enabled_plugins"
+      }
+
+      template {
+        data        = <<EOH
+cluster_formation.peer_discovery_backend = rabbit_peer_discovery_consul
+cluster_formation.consul.svc_addr_auto = true
+
+listeners.ssl.default = {{ env "NOMAD_PORT_amqp" }}
+
+management.ssl.port       = {{ env "NOMAD_PORT_ui" }}
+management.ssl.cacertfile = /secrets/ca.crt
+management.ssl.certfile   = /secrets/rabbit.crt
+management.ssl.keyfile    = /secrets/rabbit.key
+
+ssl_options.verify               = verify_peer
+ssl_options.fail_if_no_peer_cert = true
+ssl_options.cacertfile           = /secrets/ca.crt
+ssl_options.certfile             = /secrets/rabbit.crt
+ssl_options.keyfile              = /secrets/rabbit.key
+
+[[ .rabbitmq.extra_conf ]]
+        EOH
+        destination = "local/rabbitmq.conf"
+      }
+
+      [[ template "pki" .rabbitmq ]]
+
+      [[ template "rabbit_env" .rabbitmq ]]
+
+      [[ template "consul_services" .rabbitmq ]]
+
+    }
+  }
+}

--- a/packs/rabbitmq/variables.hcl
+++ b/packs/rabbitmq/variables.hcl
@@ -75,6 +75,18 @@ variable "port_ui" {
   default     = 0
 }
 
+variable "port_discovery" {
+  description = "The port RabbitMQ uses for node discovery.  Cannot be dynamically assigned."
+  type        = number
+  default     = 4369
+}
+
+variable "port_clustering" {
+  description = "The port RabbitMQ uses for clustering.  Cannot be dynamically assigned."
+  type        = number
+  default     = 25672
+}
+
 
 // ------------------------------------------------------------------------- //
 variable "pki_vault_enabled" {

--- a/packs/rabbitmq/variables.hcl
+++ b/packs/rabbitmq/variables.hcl
@@ -1,0 +1,206 @@
+variable "job_name" {
+  description = "The name to use as the job name which overrides using the pack name"
+  type        = string
+  // If "", the pack name will be used
+  default = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement"
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "cluster_size" {
+  description = "The number of RabbitMQ nodes in the cluster"
+  type        = number
+  default     = 3
+}
+
+
+variable "consul_service_amqp_tags" {
+  description = "The tags to for the AMQP port in the consul service catalog"
+  type        = list(string)
+  default     = ["amqp"]
+}
+
+variable "consul_service_management_tags" {
+  description = "The tags to for the management UI port in the consul service catalog"
+  type        = list(string)
+  default     = ["management"]
+}
+
+
+variable "vault_enabled" {
+  description = "Use Vault integration"
+  type        = bool
+  default     = true
+}
+
+variable "vault_roles" {
+  description = "The vault role(s) to assign to the node"
+  type        = list(string)
+  default     = ["rabbit"]
+}
+
+variable "image" {
+  description = "docker container to use"
+  type        = string
+  default     = "rabbitmq:3.9.10-management-alpine"
+}
+
+variable "enabled_plugins" {
+  description = "Extra plugins to enable in the cluster. rabbitmq_peer_discovery_consul is always enabled."
+  type        = list(string)
+  default = [
+    "rabbitmq_management",
+  ]
+}
+
+variable "extra_conf" {
+  description = "Extra configuration values for rabbitmq.conf file"
+  type        = string
+  default     = ""
+}
+
+variable "port_amqp" {
+  description = "The port to use for AMQP connections.  Set to 0 for random"
+  type        = number
+  default     = 0
+}
+
+variable "port_ui" {
+  description = "The port to use for RabbitMQ UI connections.  Set to 0 for random"
+  type        = number
+  default     = 0
+}
+
+
+// ------------------------------------------------------------------------- //
+variable "pki_vault_enabled" {
+  description = "Use Vault for secrets and PKI"
+  type        = bool
+  default     = true
+}
+
+variable "pki_vault_domain" {
+  description = "The domain of the nomad nodes"
+  type        = string
+  default     = ""
+}
+
+variable "pki_vault_secret_path" {
+  description = "The full path to issue a certificate for RabbitMQ from"
+  type        = string
+  default     = "pki/issue/rabbit"
+}
+
+// ------------------------------------------------------------------------- //
+variable "pki_artifact_ca_cert" {
+  description = "Configures an artifact block to pull the ca certificate"
+  type = object({
+    enabled = bool
+    source  = string
+    headers = map(string)
+    options = map(string)
+  })
+  default = {
+    enabled = false
+    source  = "https://localhost/certs/ca.crt"
+    headers = {}
+    options = {}
+  }
+}
+
+variable "pki_artifact_node_cert" {
+  description = "Configures an artifact block to pull the ca certificate"
+  type = object({
+    enabled = bool
+    source  = string
+    headers = map(string)
+    options = map(string)
+  })
+  default = {
+    enabled = false
+    source  = "https://localhost/certs/rabbit-node.crt"
+    headers = {}
+    options = {}
+  }
+}
+
+variable "pki_artifact_node_cert_key" {
+  description = "Configures an artifact block to pull the ca certificate"
+  type = object({
+    enabled = bool
+    source  = string
+    headers = map(string)
+    options = map(string)
+  })
+  default = {
+    enabled = false
+    source  = "https://localhost/certs/rabbit-node.key"
+    headers = {}
+    options = {}
+  }
+}
+
+// ------------------------------------------------------------------------- //
+
+variable "cookie_static" {
+  description = "The shared secret used by RabbitMQ nodes to join the cluster"
+  type        = string
+  default     = ""
+}
+
+variable "cookie_vault" {
+  description = "The shared secret used by RabbitMQ nodes to join the cluster"
+  type = object({
+    enabled = bool
+    path    = string
+    key     = string
+  })
+  default = {
+    enabled = true
+    path    = "secret/data/rabbit/cookie"
+    key     = "cookie"
+  }
+}
+
+// ------------------------------------------------------------------------- //
+
+variable "admin_user_vault_enabled" {
+  description = "Use Vault to set the RabbitMQ root username and password"
+  type        = bool
+  default     = true
+}
+
+variable "admin_user_vault_path" {
+  description = "The path to the username|password secret in Vault"
+  type        = string
+  default     = "secret/data/rabbit/admin"
+}
+
+variable "admin_user_vault_username_key" {
+  description = "The key to read for the username"
+  type        = string
+  default     = "username"
+}
+
+variable "admin_user_vault_password_key" {
+  description = "The key to read for the password"
+  type        = string
+  default     = "password"
+}
+
+// ------------------------------------------------------------------------- //
+
+variable "admin_user_static_username" {
+  description = "The admin username for the RabbitMQ root user.  Prefer admin_user_vault over this."
+  type        = string
+  default     = ""
+}
+variable "admin_user_static_password" {
+  description = "The admin password for the RabbitMQ root user.  Prefer admin_user_vault over this."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
This pack is based on my old blog post of [deploying a TLS enabled RabbitMQ cluster to Nomad](https://andydote.co.uk/2019/04/06/nomad-rabbitmq-secure/).  There are some changes in how the configuration is done due to how old that post is - I'll be updating it in the near future too.

This has been tested on a 3 node vagrant based Nomad cluster.

Requirements:
- Consul: I've not sure how I can specify this requires Consul, but all Nomad clusters I have used have it available.
- Vault: Optional, but strongly preferred.