### PR TITLE
grafana: Update to version 0.1.0

### DIFF
--- a/packs/grafana/CHANGELOG.md
+++ b/packs/grafana/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 Redesign of Pack
+
+- Breaking Change: all Variables related to Grafana are prefixed with `grafana_`
+- added `grafana_volume` for persistent data
+- added `grafana_task_artifacts` for custom Artifacts in Grafana
+- added `grafana_task_config_dashboards`, `grafana_task_config_datasources` and `grafana_task_config_plugins` for automatic Grafana setup
+
+## 0.0.1 Initial Release

--- a/packs/grafana/README.md
+++ b/packs/grafana/README.md
@@ -4,6 +4,25 @@
 
 This pack deploys a single instance of the Grafana docker image `grafana/grafana` and a Consul Service named "grafana". This Consul Service can be connected to other upstream Consul services deployed using Nomad. These other services are defined using the `upstreams` variable.
 
+## Variables
+
+- `job_name` (string "") - The name to use as the job name which overrides using the pack name.
+- `datacenters` (list(string) ["dc1"]) - A list of datacenters in the region which are eligible for
+  task placement.
+- `region` (string "global") - The region where the job should be placed.
+- `dns` (object) - Network DNS configuration
+- `grafana_version_tag` (string "latest" ) - The version of Grafana Image
+- `grafana_http_port` (number "3000" ) - The Grafana Port for http
+- `grafana_upstreams` (list(object)) - Upstream configuration for sidecar proxy
+- `grafana_resources` (object) - CPU and Memory configuration for Grafana
+- `grafana_consul_tags` (list(string)) - Service tag definition for Consul
+- `grafana_volume` (object) - Persistent Volume configuration for Grafana
+- `grafana_env_vars` (list(object)) - Environment Variables for Grafana
+- `grafana_task_artifacts` (list(object)) - Nomad Artifacts for Grafana
+- `grafana_task_config_dashboards` (string) - Yaml configuration for automatic provision of dashboards
+- `grafana_task_config_datasources` (string) - Yaml configuration for automatic provision of datasources
+- `grafana_task_config_plugins` (string) - yaml configuration for automatic provision of plugins
+
 ## Dependencies
 
 This pack requires Linux clients to run properly.

--- a/packs/grafana/metadata.hcl
+++ b/packs/grafana/metadata.hcl
@@ -7,5 +7,5 @@ pack {
   name        = "grafana"
   description = "Grafana is a multi-platform open source analytics and interactive visualization web application."
   url         = "https://github.com/hashicorp/nomad-pack-community-registry/grafana"
-  version     = "0.0.1"
+  version     = "0.1.0"
 }

--- a/packs/grafana/templates/grafana.nomad.tpl
+++ b/packs/grafana/templates/grafana.nomad.tpl
@@ -14,14 +14,37 @@ job [[ template "job_name" . ]] {
     network {
       mode = "bridge"
 
+    [[- if .grafana.dns ]]
+    dns {
+      [[- if .grafana.dns.source ]]
+        servers = [[ .grafana.dns.source | toPrettyJson ]]
+      [[- end ]]
+      [[- if .grafana.dns.searches ]]
+        searches = [[ .grafana.dns.searches | toPrettyJson ]]
+      [[- end ]]
+      [[- if .grafana.dns.options ]]
+        options = [[ .grafana.dns.options | toPrettyJson ]]
+      [[- end ]]
+    }
+    [[- end ]]
+
       port "http" {
-        to = [[ .grafana.http_port ]]
+        to = [[ .grafana.grafana_http_port ]]
       }
     }
 
+    [[- if .grafana.grafana_volume ]]
+    volume "grafana" {
+      type = [[ .grafana.grafana_volume.type | quote ]]
+      read_only = false
+      source = [[ .grafana.grafana_volume.source | quote ]]
+    }
+    [[- end ]]
+
     service {
       name = "grafana"
-      port = "[[ .grafana.http_port ]]"
+      port = "[[ .grafana.grafana_http_port ]]"
+      tags = [[ .grafana.grafana_consul_tags | toPrettyJson ]]
 
       connect {
         sidecar_service {
@@ -40,15 +63,76 @@ job [[ template "job_name" . ]] {
     task "grafana" {
       driver = "docker"
 
+    [[- if .grafana.grafana_volume ]]
+      volume_mount {
+        volume      = "grafana"
+        destination = "/var/lib/grafana"
+        read_only   = false
+      }
+    [[- end ]]
+
       config {
-        image = "grafana/grafana:[[ .grafana.version_tag ]]"
+        image = "grafana/grafana:[[ .grafana.grafana_version_tag ]]"
         ports = ["http"]
       }
 
       resources {
-        cpu    = [[ .grafana.resources.cpu ]]
-        memory = [[ .grafana.resources.memory ]]
+        cpu    = [[ .grafana.grafana_resources.cpu ]]
+        memory = [[ .grafana.grafana_resources.memory ]]
       }
+
+      env {
+        [[- range $var := .grafana.grafana_env_vars ]]
+        [[ $var.key ]] = "[[ $var.value ]]"
+        [[- end ]]
+      }
+
+      [[- if .grafana.grafana_task_artifacts ]]
+        [[- range $artifact := .grafana.grafana_task_artifacts ]]
+
+      artifact {
+        source      = [[ $artifact.source | quote ]]
+        destination = [[ $artifact.destination | quote ]]
+        mode = [[ $artifact.mode | quote ]]
+        [[- if $artifact.options ]]
+        options {
+          [[- range $option, $val := $artifact.options ]]
+          [[ $option ]] = [[ $val | quote ]]
+          [[- end ]]
+        }
+        [[- end ]]
+
+      }
+        [[- end ]]
+      [[- end ]]
+
+      [[- if .grafana.grafana_task_config_dashboards ]]
+      template {
+        data = <<EOF
+[[ .grafana.grafana_task_config_dashboards ]]
+EOF
+        destination = "/local/grafana/provisioning/dashboards/dashboards.yaml"
+      }
+      [[- end ]]
+
+      [[- if .grafana.grafana_task_config_datasources ]]
+      template {
+        data = <<EOF
+[[ .grafana.grafana_task_config_datasources ]]
+EOF
+        destination = "/local/grafana/provisioning/datasources/datasources.yaml"
+      }
+      [[- end ]]
+
+      [[- if .grafana.grafana_task_config_plugins ]]
+
+      template {
+        data = <<EOF
+[[ .grafana.grafana_task_config_plugins ]]
+EOF
+        destination = "/local/grafana/provisioning/plugins/plugins.yml"
+      }
+    [[- end ]]
     }
   }
 }

--- a/packs/grafana/variables.hcl
+++ b/packs/grafana/variables.hcl
@@ -1,7 +1,6 @@
 variable "job_name" {
   description = "The name to use as the job name which overrides using the pack name"
   type        = string
-  // If "", the pack name will be used
   default = ""
 }
 
@@ -17,19 +16,28 @@ variable "region" {
   default     = "global"
 }
 
-variable "version_tag" {
+variable "dns" {
+  description = ""
+  type = object({
+    servers   = list(string)
+    searches = list(string)
+    options = list(string)
+  })
+}
+
+variable "grafana_version_tag" {
   description = "The docker image version. For options, see https://hub.docker.com/grafana/grafana"
   type        = string
   default     = "latest"
 }
 
-variable "http_port" {
+variable "grafana_http_port" {
   description = "The Nomad client port that routes to the Grafana"
   type        = number
   default     = 3000
 }
 
-variable "upstreams" {
+variable "grafana_upstreams" {
   description = ""
   type = list(object({
     name = string
@@ -37,7 +45,7 @@ variable "upstreams" {
   }))
 }
 
-variable "resources" {
+variable "grafana_resources" {
   description = "The resource to assign to the Grafana service task"
   type = object({
     cpu    = number
@@ -47,4 +55,102 @@ variable "resources" {
     cpu    = 200,
     memory = 256
   }
+}
+
+variable "grafana_consul_tags" {
+  description = ""
+  type = list(string)
+  default = []
+}
+
+variable "grafana_volume" {
+  description = "The resource to assign to the Grafana service task"
+  type = object({
+    type    = string
+    source = string
+  })
+}
+
+variable "grafana_env_vars" {
+  description = ""
+  type = list(object({
+    key   = string
+    value = string
+  }))
+  default = [
+    {key = "GF_LOG_LEVEL", value = "DEBUG"},
+    {key = "GF_LOG_MODE", value = "console"},
+    {key = "GF_SERVER_HTTP_PORT", value = "$${NOMAD_PORT_http}"},
+    {key = "GF_PATHS_PROVISIONING", value = "/local/grafana/provisioning"}
+  ]
+}
+
+variable "grafana_task_artifacts" {
+  description = "Define external artifacts for Grafana."
+  type = list(object({
+    source   = string
+    destination = string
+    options = map(string)
+  }))
+  default = [
+    {
+      source = "https://grafana.com/api/dashboards/1860/revisions/26/download",
+      destination = "local/grafana/provisioning/dashboards/linux/linux-node-exporter.json"
+      mode = "file"
+      options = null
+    },
+  ]
+}
+
+variable "grafana_task_config_dashboards" {
+  description = "The yaml configuration for automatic provision of dashboards"
+  type        = string
+  default     = <<EOF
+apiVersion: 1
+
+providers:
+  - name: dashboards
+    type: file
+    updateIntervalSeconds: 30
+    options:
+      foldersFromFilesStructure: true
+      path: /local/grafana/provisioning/dashboards
+EOF
+}
+
+variable "grafana_task_config_datasources" {
+  description = "The yaml configuration for automatic provision of datasources"
+  type        = string
+  default     = <<EOF
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus.service.{{ env "NOMAD_DC" }}.consul:9090
+    jsonData:
+      exemplarTraceIdDestinations:
+        - name: traceID
+          datasourceUid: tempo
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo.service.{{ env "NOMAD_DC" }}.consul:3400
+    uid: tempo
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki.service.{{ env "NOMAD_DC" }}.consul:3100
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: (?:traceID|trace_id)=(\w+)
+          name: TraceID
+          url: $$${__value.raw}
+EOF
+}
+
+variable "grafana_task_config_plugins" {
+  description = "The yaml configuration for automatic provision of plugins"
+  type        = string
 }


### PR DESCRIPTION
- Breaking Change: all Variables related to Grafana are prefixed with `grafana_`
- added `grafana_volume` for persistent data
- added `grafana_task_artifacts` for custom Artifacts in Grafana
- added `grafana_task_config_dashboards`, `grafana_task_config_datasources` and `grafana_task_config_plugins` for automatic Grafana setup