### PR TITLE
Pack: HashiCups

### DIFF
--- a/packs/hashicups/README.md
+++ b/packs/hashicups/README.md
@@ -1,0 +1,54 @@
+# HashiCups
+
+[HashiCups](https://github.com/hashicorp-demoapp) is a demo webapp of a coffee shop application. This pack is configured to run on a Nomad cluster without the use of Consul for service discovery.
+
+## Variables
+
+|Variable|Default Value (type)|Description|
+|---|---|---|
+|`datacenters`|`["dc1"]` (list of strings)|A list of datacenters in the region which are eligible for task placement.|
+|`region`|`global` (string)|The region where the job should be placed.|
+|`frontend_version`|`v1.0.2` (string)|Frontend Docker image version.|
+|`public_api_version`|`v0.0.6` (string)|Public API Docker image version.|
+|`payments_version`|`v0.0.12` (string)|Payments API Docker image version.|
+|`product_api_version`|`v0.0.20` (string)|Products API Docker image version.|
+|`product_api_db_version`|`v0.0.20` (string)|Products API database Docker image version.|
+|`postgres_db`|`products` (string)|The Postgres database name.|
+|`postgres_user`|`postgres` (string)|The Postgres database user.|
+|`postgres_password`|`password` (string)|The Postgres database user's password.|
+|`db_port`|`5432` (number)|The Postgres database port.|
+|`product_api_port`|`9090` (number)|The products API service port.|
+|`frontend_port`|`3000` (number)|The frontend service port.|
+|`payments_api_port`|`8080` (number)|The payments API service port.|
+|`public_api_port`|`8081` (number)|The public API service port.|
+|`nginx_port`|`80` (number)|The Nginx reverse proxy port.|
+
+## Prerequisites
+
+- Nomad cluster (a [local dev cluster](https://learn.hashicorp.com/tutorials/nomad/get-started-run) will work) with Docker available on the node(s)
+- Ability to access Nomad client on port 80
+
+## Docker Desktop Notes
+If you are running Nomad on your local machine with Docker Desktop, you'll need to bind the Nomad client to a non-loopback network interface so that the containers can communicate with each other.
+
+```
+$ nomad agent -dev -bind=0.0.0.0 -network-interface=en0
+```
+
+This will bind to the `en0` interface. You can retrieve the IP address associated with it by inspecting the interface and looking at the line starting with `inet`.
+
+```
+$ ifconfig
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=400<CHANNEL_IO>
+	ether 88:66:5a:44:34:e8 
+	inet6 fe80::c5c:1de8:d154:9341%en0 prefixlen 64 secured scopeid 0x6 
+	inet 192.168.1.6 netmask 0xffffff00 broadcast 192.168.1.255
+	nd6 options=201<PERFORMNUD,DAD>
+	media: autoselect
+	status: active
+```
+
+With the above configuration, the Nomad UI can be accessed at `192.168.1.6:4646` and the HashiCups UI can be accessed with the same IP address on port `80` by default.
+
+See [this FAQ page](https://www.nomadproject.io/docs/faq#q-how-to-connect-to-my-host-network-when-using-docker-desktop-windows-and-macos) for more information.

--- a/packs/hashicups/README.md
+++ b/packs/hashicups/README.md
@@ -16,7 +16,6 @@
 |`postgres_db`|`products` (string)|The Postgres database name.|
 |`postgres_user`|`postgres` (string)|The Postgres database user.|
 |`postgres_password`|`password` (string)|The Postgres database user's password.|
-|`db_port`|`5432` (number)|The Postgres database port.|
 |`product_api_port`|`9090` (number)|The products API service port.|
 |`frontend_port`|`3000` (number)|The frontend service port.|
 |`payments_api_port`|`8080` (number)|The payments API service port.|
@@ -26,7 +25,7 @@
 ## Prerequisites
 
 - Nomad cluster (a [local dev cluster](https://learn.hashicorp.com/tutorials/nomad/get-started-run) will work) with Docker available on the node(s)
-- Ability to access Nomad client on port 80
+- Ability to access Nomad client on the port defined in the `nginx_port` variable
 
 ## Docker Desktop Notes
 If you are running Nomad on your local machine with Docker Desktop, you'll need to bind the Nomad client to a non-loopback network interface so that the containers can communicate with each other.

--- a/packs/hashicups/metadata.hcl
+++ b/packs/hashicups/metadata.hcl
@@ -5,7 +5,7 @@ app {
 
 pack {
   name = "hashicups"
-  description = "This is Hashicorp's HashiCups Demo App deployed as a Nomad Pack"
-  url = "https://github.com/tunzor/nomad-pack-test"
+  description = "HashiCups Demo coffee application."
+  url = "https://github.com/hashicorp/nomad-pack-community-registry/hashicups"
   version = "0.0.1"
 }

--- a/packs/hashicups/metadata.hcl
+++ b/packs/hashicups/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url = "https://github.com/hashicorp-demoapp"
+  author = "HashiCorp"
+}
+
+pack {
+  name = "hashicups"
+  description = "This is Hashicorp's HashiCups Demo App deployed as a Nomad Pack"
+  url = "https://github.com/tunzor/nomad-pack-test"
+  version = "0.0.1"
+}

--- a/packs/hashicups/outputs.tpl
+++ b/packs/hashicups/outputs.tpl
@@ -1,0 +1,9 @@
+Congratulations on deploying [[ .nomad_pack.pack.name ]]! 
+
+Navigate to the HashiCups UI on port [[ .hashicups.nginx_port ]] of the Nomad client running the job.
+
+You can find the allocation ID with:
+nomad job status hashicups | grep -A 3 -i allocations
+
+Then display the address of each service with the allocation ID from above:
+nomad alloc status <ALLOC_ID> | grep -A 8 -i allocation

--- a/packs/hashicups/templates/hashicups.nomad.tpl
+++ b/packs/hashicups/templates/hashicups.nomad.tpl
@@ -1,7 +1,7 @@
 job "hashicups" {
   type   = "service"
   region = "[[ .hashicups.region ]]"
-  datacenters = [ [[ range $idx, $dc := .hashicups.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+  datacenters = [[ .hashicups.datacenters | toStringList ]]
 
   group "hashicups" {
     network {

--- a/packs/hashicups/templates/hashicups.nomad.tpl
+++ b/packs/hashicups/templates/hashicups.nomad.tpl
@@ -1,0 +1,159 @@
+job "hashicups" {
+  type   = "service"
+  region = "[[ .hashicups.region ]]"
+  datacenters = [ [[ range $idx, $dc := .hashicups.datacenters ]][[if $idx]],[[end]][[ $dc | quote ]][[ end ]] ]
+
+  group "hashicups" {
+    network {
+      port "db" { 
+        static = [[ .hashicups.db_port ]]
+      }
+      port "product-api" {
+        static = [[ .hashicups.product_api_port ]]
+      }
+      port "frontend" {
+        static = [[ .hashicups.frontend_port ]]
+      }
+      port "payments-api" {
+        static = [[ .hashicups.payments_api_port ]]
+      }
+      port "public-api" {
+        static = [[ .hashicups.public_api_port ]]
+      }
+      port "nginx" {
+        static = [[ .hashicups.nginx_port ]]
+      }
+    }
+
+    task "db" {
+      driver = "docker"
+      meta {
+        service = "database"
+      }
+      config {
+        image   = "hashicorpdemoapp/product-api-db:[[ .hashicups.product_api_db_version ]]"
+        ports = ["db"]
+      }
+      env {
+        POSTGRES_DB       = "[[ .hashicups.postgres_db ]]"
+        POSTGRES_USER     = "[[ .hashicups.postgres_user ]]"
+        POSTGRES_PASSWORD = "[[ .hashicups.postgres_password ]]"
+      }
+    }
+
+    task "product-api" {
+      driver = "docker"
+      meta {
+        service = "product-api"
+      }
+      config {
+        image   = "hashicorpdemoapp/product-api:[[ .hashicups.product_api_version ]]"
+        ports = ["product-api"]
+      }
+      env {
+        DB_CONNECTION = "host=${NOMAD_IP_db} port=[[ .hashicups.db_port ]] user=[[ .hashicups.postgres_user ]] password=[[ .hashicups.postgres_password ]] dbname=[[ .hashicups.postgres_db ]] sslmode=disable"
+        BIND_ADDRESS = "0.0.0.0:[[ .hashicups.product_api_port ]]"
+      }
+    }
+
+    task "payments-api" {
+      driver = "docker"
+      meta {
+        service = "payments-api"
+      }
+      config {
+        image   = "hashicorpdemoapp/payments:[[ .hashicups.payments_version ]]"
+        ports = ["payments-api"]
+      }
+    }
+    
+    task "public-api" {
+      driver = "docker"
+      meta {
+        service = "public-api"
+      }
+      config {
+        image   = "hashicorpdemoapp/public-api:[[ .hashicups.public_api_version ]]"
+        ports = ["public-api"]
+      }
+      env {
+        BIND_ADDRESS = ":[[ .hashicups.public_api_port ]]"
+        PRODUCT_API_URI = "http://${NOMAD_ADDR_product-api}"
+        PAYMENT_API_URI = "http://${NOMAD_ADDR_payments-api}"
+      }
+    }
+    
+    task "frontend" {
+      driver = "docker"
+      meta {
+        service = "frontend"
+      }
+      env {
+        NEXT_PUBLIC_PUBLIC_API_URL= "/"
+      }
+      config {
+        image   = "hashicorpdemoapp/frontend:[[ .hashicups.frontend_version ]]"
+        ports = ["frontend"]
+      }
+    }
+
+    task "nginx" {
+      driver = "docker"
+      meta {
+        service = "nginx-reverse-proxy"
+      }
+      config {
+        image = "nginx:alpine"
+        ports = ["nginx"]
+        mount {
+          type   = "bind"
+          source = "local/default.conf"
+          target = "/etc/nginx/conf.d/default.conf"
+        }
+      }
+      template {
+        data =  <<EOF
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=STATIC:10m inactive=7d use_temp_path=off;
+upstream frontend_upstream {
+  server {{ env "NOMAD_IP_frontend" }}:[[ .hashicups.frontend_port ]];
+}
+server {
+  listen [[ .hashicups.nginx_port ]];
+  server_name  {{ env "NOMAD_IP_nginx" }};
+  server_tokens off;
+  gzip on;
+  gzip_proxied any;
+  gzip_comp_level 4;
+  gzip_types text/css application/javascript image/svg+xml;
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection 'upgrade';
+  proxy_set_header Host $host;
+  proxy_cache_bypass $http_upgrade;
+  location /_next/static {
+    proxy_cache STATIC;
+    proxy_pass http://frontend_upstream;
+    # For testing cache - remove before deploying to production
+    add_header X-Cache-Status $upstream_cache_status;
+  }
+  location /static {
+    proxy_cache STATIC;
+    proxy_ignore_headers Cache-Control;
+    proxy_cache_valid 60m;
+    proxy_pass http://frontend_upstream;
+    # For testing cache - remove before deploying to production
+    add_header X-Cache-Status $upstream_cache_status;
+  }
+  location / {
+    proxy_pass http://frontend_upstream;
+  }
+  location /api {
+    proxy_pass http://{{ env "NOMAD_IP_frontend" }}:[[ .hashicups.public_api_port ]];
+  }
+}
+        EOF
+        destination = "local/default.conf"
+      }
+    }
+  }
+}

--- a/packs/hashicups/templates/hashicups.nomad.tpl
+++ b/packs/hashicups/templates/hashicups.nomad.tpl
@@ -89,8 +89,8 @@ server.port={{ env "NOMAD_PORT_payments-api" }}
       }
       env {
         BIND_ADDRESS = ":${NOMAD_PORT_public-api}"
-        PRODUCT_API_URI = "http://${NOMAD_IP_product-api}:${NOMAD_PORT_product-api}"
-        PAYMENT_API_URI = "http://${NOMAD_IP_payments-api}:${NOMAD_PORT_payments-api}"
+        PRODUCT_API_URI = "http://${NOMAD_ADDR_product-api}"
+        PAYMENT_API_URI = "http://${NOMAD_ADDR_payments-api}"
       }
     }
     

--- a/packs/hashicups/variables.hcl
+++ b/packs/hashicups/variables.hcl
@@ -50,11 +50,6 @@ variable "postgres_password" {
   default = "password"
 }
 
-variable "db_port" {
-  description = "Postgres DB Port"
-  default = 5432
-}
-
 variable "product_api_port" {
   description = "Product API Port"
   default = 9090

--- a/packs/hashicups/variables.hcl
+++ b/packs/hashicups/variables.hcl
@@ -1,0 +1,81 @@
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement."
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "region" {
+  description = "The region where the job should be placed."
+  type        = string
+  default     = "global"
+}
+
+variable "frontend_version" {
+  description = "Docker version tag"
+  default = "v1.0.2"
+}
+
+variable "public_api_version" {
+  description = "Docker version tag"
+  default = "v0.0.6"
+}
+
+variable "payments_version" {
+  description = "Docker version tag"
+  default = "v0.0.12"
+}
+
+variable "product_api_version" {
+  description = "Docker version tag"
+  default = "v0.0.20"
+}
+
+variable "product_api_db_version" {
+  description = "Docker version tag"
+  default = "v0.0.20"
+}
+
+variable "postgres_db" {
+  description = "Postgres DB name"
+  default = "products"
+}
+
+variable "postgres_user" {
+  description = "Postgres DB User"
+  default = "postgres"
+}
+
+variable "postgres_password" {
+  description = "Postgres DB Password"
+  default = "password"
+}
+
+variable "db_port" {
+  description = "Postgres DB Port"
+  default = 5432
+}
+
+variable "product_api_port" {
+  description = "Product API Port"
+  default = 9090
+}
+
+variable "frontend_port" {
+  description = "Frontend Port"
+  default = 3000
+}
+
+variable "payments_api_port" {
+  description = "Payments API Port"
+  default = 8080
+}
+
+variable "public_api_port" {
+  description = "Public API Port"
+  default = 8081
+}
+
+variable "nginx_port" {
+  description = "Nginx Port"
+  default = 80
+}


### PR DESCRIPTION
A pack for the HashiCups demo application that deploys the app without the need for Consul (services run on static ports).

Requirements: 
- Nomad cluster (dev cluster works fine) with Docker installed
- Ability to access the Nomad client on the `nginx_port` defined in the variables file