### PR TITLE
AWS EBS CSI plugin

### DIFF
--- a/packs/aws_ebs_csi/CHANGELOG.md
+++ b/packs/aws_ebs_csi/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0
+
+- Initial release

--- a/packs/aws_ebs_csi/README.md
+++ b/packs/aws_ebs_csi/README.md
@@ -1,0 +1,135 @@
+# AWS EBS CSI plugin
+
+This pack deploys two jobs that run the [AWS
+EBS](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) CSI
+plugin. The node plugin tasks will be run as a system job, and the
+controller tasks will be run as a service job.
+
+## Client Requirements
+
+This pack can only be run on Nomad clients that have enabled volumes
+and privileged mode for the Docker task driver. In addition, clients
+will need to be deployed in every availability zone where you intend
+to create volumes.
+
+## Variables
+
+* `job_name` (string "democratic_csi") - The prefix to use as the job
+  name for the plugins. For exmaple, if `job_name = "democratic_csi"`,
+  the plugin job will be named `democratic_csi_controller`.
+* `datacenters` (list(string) ["dc1"]) - A list of datacenters in the
+  region which are eligible for task placement.
+* `region` (string "global") - The region where the job should be
+  placed.
+* `plugin_id` (string "org.democratic-csi.nfs") - The ID to register
+  in Nomad for the plugin.
+* `plugin_namespace` (string "default") - The namespace for the plugin
+  job.
+* `plugin_image` (string
+  "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.5.1") - The container
+  image for the plugin.
+* `plugin_csi_spec_version` (string "1.5.0") - The CSI spec version
+  that democratic-csi will comply with.
+* `plugin_log_level` (string "debug") - The log level for the plugin.
+* `availability_zones` (list(string) ["us-east-1b"]) - AWS
+  availability zones for the node plugins and example volume output.
+* `controller_count` (number 2) - The number of controller instances
+  to be deployed (at least 2 recommended).
+* `volume_id` (string "myvolume") - ID for the example volume spec to
+  output.
+* `volume_namespace` (string "default") - Namespace for the example
+  volume spec to output.
+* `volume_min_capacity` (string "10GiB") - Minimum capacity for the example volume spec to output.
+* `volume_max_capacity` (string "30GiB") - Maximum capacity for the example volume spec to output.
+* `volume_type` (string "gp2") - AWS EBS volume type.
+
+#### `constraints` List of Objects
+
+[Nomad job specification
+constraints](https://www.nomadproject.io/docs/job-specification/constraint)
+allow restricting the set of eligible nodes on which the tasks will
+run. This pack automatically configures the following required
+constraints:
+
+* Plugin tasks will run on Linux hosts only
+* The node plugin tasks will run on hosts with the Docker driver's
+  [`volumes`](https://www.nomadproject.io/docs/drivers/docker#volumes-1)
+  enabled and
+  [`allow_privileged`](https://www.nomadproject.io/docs/drivers/docker#allow_privileged)
+  set to `true`.
+* The controller plugin tasks will be deployed on distinct hosts.
+
+You can set additional constraints with the `constraints` variable,
+which takes a list of objects with the following fields:
+
+* `attribute` (string) - Specifies the name or reference of the
+  attribute to examine for the constraint.
+* `operator` (string) - Specifies the comparison operator. The
+  ordering is compared lexically.
+* `value` (string) - Specifies the value to compare the attribute
+  against using the specified operation.
+
+Below is also an example of how to pass `constraints` to the CLI with
+with the `-var` argument.
+
+```bash
+nomad-pack run -var 'constraints=[{"attribute":"$${meta.my_custom_value}","operator":">","value":"3"}]' packs/aws_ebs_csi
+```
+
+#### `resources` Object
+
+* `cpu` (number 500) - Specifies the CPU required to run this task in
+  MHz.
+* `memory` (number 256) - Specifies the memory required in MB.
+
+## Volume creation
+
+This pack outputs an example volume specification based on the plugin variables.
+
+#### **`volume.hcl`**
+
+```hcl
+type         = "csi"
+id           = "myvolume"
+namespace    = "default"
+plugin_id    = "ebs.csi.aws.com"
+
+# this is used as the AWS EBS volume's CSIVolumeName tag, and
+# must be unique per region
+name         = "eecede36-6de0-4de1-9a06-6d201c29e2a2"
+
+capacity_min = "10GiB"
+capacity_max = "30GiB"
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "block-device"
+}
+
+parameters {
+  type = "gp2"
+}
+
+topology_request {
+  required {
+    topology {
+      segments {
+
+        "topology.ebs.csi.aws.com/zone" = "us-east-1a"
+        "topology.ebs.csi.aws.com/zone" = "us-east-1b"
+      }
+    }
+  }
+}
+```
+
+Create this volume with the following command:
+
+```sh
+nomad volume create volume.hcl
+```

--- a/packs/aws_ebs_csi/metadata.hcl
+++ b/packs/aws_ebs_csi/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = "https://github.com/kubernetes-sigs/aws-ebs-csi-driver"
+  author = "Tim Gross <tgross@hashicorp.com>"
+}
+
+pack {
+  name        = "aws_ebs_csi"
+  description = "This pack deploys the AWS EBS CSI plugin"
+  url         = "https://github.com/hashicorp/nomad-pack-community-registry/aws_ebs_csi"
+  version     = "0.1.0"
+}

--- a/packs/aws_ebs_csi/outputs.tpl
+++ b/packs/aws_ebs_csi/outputs.tpl
@@ -1,0 +1,38 @@
+type         = "csi"
+id           = "[[ .my.volume_id ]]"
+namespace    = "[[ .my.volume_namespace ]]"
+plugin_id    = "[[ .my.plugin_id ]]"
+
+# this is used as the AWS EBS volume's CSIVolumeName tag, and
+# must be unique per region
+name         = "[[ uuidv4 ]]"
+
+capacity_min = "[[ .my.volume_min_capacity ]]"
+capacity_max = "[[ .my.volume_max_capacity ]]"
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "block-device"
+}
+
+parameters {
+  type = "[[ .my.volume_type ]]"
+}
+
+topology_request {
+  required {
+    topology {
+      segments {
+[[ if .my.availability_zones -]][[ range $idx, $az := .my.availability_zones ]]
+        "topology.ebs.csi.aws.com/zone" = "[[ $az ]]"
+[[- end -]]
+[[- end ]]
+      }
+    }
+  }
+}

--- a/packs/aws_ebs_csi/templates/_constraints.tpl
+++ b/packs/aws_ebs_csi/templates/_constraints.tpl
@@ -1,0 +1,18 @@
+[[- define "constraints" -]]
+constraint {
+      attribute = "${attr.kernel.name}"
+      value     = "linux"
+    }
+
+[[- if .my.constraints -]][[ range $idx, $constraint := .my.constraints ]]
+    constraint {
+      attribute = [[ $constraint.attribute | quote ]]
+  [[- if $constraint.value ]]
+      value     = [[ $constraint.value | quote ]]
+  [[- end ]]
+      [[- if $constraint.operator  ]]
+      operator  = [[ $constraint.operator | quote ]]
+  [[- end ]]
+    }
+[[- end ]][[- end ]]
+[[- end -]]

--- a/packs/aws_ebs_csi/templates/_location.tpl
+++ b/packs/aws_ebs_csi/templates/_location.tpl
@@ -1,0 +1,5 @@
+[[- define "location" ]]
+  namespace   = "[[ .my.plugin_namespace ]]"
+  region      = "[[ .my.region ]]"
+  datacenters = [[ .my.datacenters | toJson ]]
+[[- end -]]

--- a/packs/aws_ebs_csi/templates/_resources.tpl
+++ b/packs/aws_ebs_csi/templates/_resources.tpl
@@ -1,0 +1,6 @@
+[[- define "resources" ]]
+      resources {
+        cpu    = [[ .my.resources.cpu ]]
+        memory = [[ .my.resources.memory ]]
+      }
+[[- end -]]

--- a/packs/aws_ebs_csi/templates/controller.nomad.tpl
+++ b/packs/aws_ebs_csi/templates/controller.nomad.tpl
@@ -1,0 +1,40 @@
+job "[[ .my.job_name ]]_controller" {
+
+  [[ template "location" . ]]
+
+  group "controllers" {
+
+    count = [[ .my.controller_count ]]
+
+    [[ template "constraints" . ]]
+
+    constraint {
+      operator = "distinct_hosts"
+      value    = "true"
+    }
+
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image = "[[ .my.plugin_image ]]"
+
+        args = [
+          "controller",
+          "--endpoint=${CSI_ENDPOINT}",
+          "--logtostderr",
+          "--v=5",
+        ]
+      }
+
+      csi_plugin {
+        id        = "[[ .my.plugin_id ]]"
+        type      = "controller"
+        mount_dir = "/csi"
+      }
+
+      [[ template "resources" . ]]
+
+    }
+  }
+}

--- a/packs/aws_ebs_csi/templates/node.nomad.tpl
+++ b/packs/aws_ebs_csi/templates/node.nomad.tpl
@@ -1,0 +1,43 @@
+job "[[ .my.job_name ]]_node" {
+
+  # you can run node plugins as service jobs as well, but this ensures
+  # that all nodes in the DC have a copy.
+  type = "system"
+  [[ template "location" . ]]
+
+  group "nodes" {
+
+    [[ template "constraints" . ]]
+
+    constraint {
+      attribute = "${attr.driver.docker.privileged.enabled}"
+      value     = true
+    }
+
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image = "[[ .my.plugin_image ]]"
+
+        args = [
+          "node",
+          "--endpoint=${CSI_ENDPOINT}",
+          "--logtostderr",
+          "--v=5",
+        ]
+
+        privileged = true
+      }
+
+      csi_plugin {
+        id        = "[[ .my.plugin_id ]]"
+        type      = "node"
+        mount_dir = "/csi"
+      }
+
+      [[ template "resources" . ]]
+
+    }
+  }
+}

--- a/packs/aws_ebs_csi/variables.hcl
+++ b/packs/aws_ebs_csi/variables.hcl
@@ -1,0 +1,106 @@
+variable "job_name" {
+  description = "The prefix to use as the job name for the plugins (ex. aws_ebs_controller for the controller)."
+  type        = string
+  default     = "aws_ebs"
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement."
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "region" {
+  description = "The region where the job should be placed."
+  type        = string
+  default     = "global"
+}
+
+variable "plugin_id" {
+  description = "The ID to register in Nomad for the plugin."
+  type        = string
+  default     = "ebs.csi.aws.com"
+}
+
+variable "plugin_namespace" {
+  description = "The namespace for the plugin job."
+  type        = string
+  default     = "default"
+}
+
+# note: there's no "latest" published for this image
+variable "plugin_image" {
+  description = "The container image for the plugin."
+  type        = string
+  default     = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.5.1"
+}
+
+variable "plugin_log_level" {
+  description = "The log level for the plugin."
+  type        = string
+  default     = "debug"
+}
+
+variable "controller_count" {
+  description = "The number of controller instances to be deployed (at least 2 recommended)."
+  type        = number
+  default     = 2
+}
+
+variable "constraints" {
+  description = "Additional constraints to apply to the jobs."
+  type = list(object({
+    attribute = string
+    operator  = string
+    value     = string
+  }))
+  default = []
+}
+
+variable "availability_zones" {
+  description = "AWS availability zones for the node plugins and example volume output."
+  type        = list(string)
+  default     = ["us-east-1b"]
+}
+
+variable "resources" {
+  description = "The resources to assign to the plugin tasks."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 500,
+    memory = 256
+  }
+}
+
+variable "volume_id" {
+  description = "ID for the example volume spec to output."
+  type        = string
+  default     = "myvolume"
+}
+
+variable "volume_namespace" {
+  description = "Namespace for the example volume spec to output."
+  type        = string
+  default     = "default"
+}
+
+variable "volume_min_capacity" {
+  description = "Minimum capacity for the example volume spec to output."
+  type        = string
+  default     = "10GiB"
+}
+
+variable "volume_max_capacity" {
+  description = "Maximum capacity for the example volume spec to output."
+  type        = string
+  default     = "30GiB"
+}
+
+variable "volume_type" {
+  description = "AWS EBS volume type."
+  type        = string
+  default     = "gp2"
+}


### PR DESCRIPTION
A pack for deploying the AWS EBS CSI plugin.

Example runs in my end-to-end environment on AWS:

<details><summary>plan output</summary>

```
$ nomad-pack plan packs/aws_ebs_csi
+ Job: "aws_ebs_controller"
+ Task Group: "controllers" (2 create)
  + Task: "plugin" (forces create)

» Scheduler dry-run:
- All tasks successfully allocated.
+ Job: "aws_ebs_node"
+ Task Group: "nodes" (2 create)
  + Task: "plugin" (forces create)

» Scheduler dry-run:
- All tasks successfully allocated.
Plan succeeded
```

</details>

<details><summary>run output</summary>

```
$ nomad-pack run -var 'availability_zones=["us-east-1a","us-east-1b"]' packs/aws_ebs_csi
  Evaluation ID: 8c111149-79cf-1ce4-2e2a-be9e4402d6f3
  Job 'aws_ebs_node' in pack deployment 'aws_ebs_csi' registered successfully
  Evaluation ID: b9a60aec-9287-613d-2f27-ae484b3926d4
  Job 'aws_ebs_controller' in pack deployment 'aws_ebs_csi' registered successfully
Pack successfully deployed. Use packs/aws_ebs_csi to manage this this deployed instance with
plan, stop, destroy, or info

type         = "csi"
id           = "myvolume"
namespace    = "default"
plugin_id    = "ebs.csi.aws.com"

# this is used as the AWS EBS volume's CSIVolumeName tag, and
# must be unique per region
name         = "eecede36-6de0-4de1-9a06-6d201c29e2a2"

capacity_min = "10GiB"
capacity_max = "30GiB"

capability {
  access_mode     = "single-node-writer"
  attachment_mode = "file-system"
}

capability {
  access_mode     = "single-node-writer"
  attachment_mode = "block-device"
}

parameters {
  type = "gp2"
}

topology_request {
  required {
    topology {
      segments {

        "topology.ebs.csi.aws.com/zone" = "us-east-1a"
        "topology.ebs.csi.aws.com/zone" = "us-east-1b"
      }
    }
  }
}

# after copying that volume spec to volume.hcl
$ nomad volume create ./volume.hcl
Created external volume vol-0c8788c2d8acac431 with ID myvolume

$ nomad volume status myvolume
ID                   = myvolume
Name                 = eecede36-6de0-4de1-9a06-6d201c29e2a2
External ID          = vol-0c8788c2d8acac431
Plugin ID            = ebs.csi.aws.com
Provider             = ebs.csi.aws.com
Version              = v1.5.1
Schedulable          = true
Controllers Healthy  = 2
Controllers Expected = 2
Nodes Healthy        = 2
Nodes Expected       = 2
Access Mode          = <none>
Attachment Mode      = <none>
Mount Options        = <none>
Namespace            = default

Topologies
Topology  Segments
00        topology.ebs.csi.aws.com/zone=us-east-1b

Allocations
No allocations placed
```

</details>
