### PR TITLE
Ceph RBD CSI plugin

### DIFF
--- a/packs/ceph/CHANGELOG.md
+++ b/packs/ceph/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0
+
+- Initial release

--- a/packs/ceph/README.md
+++ b/packs/ceph/README.md
@@ -1,0 +1,90 @@
+# Ceph
+
+This pack deploys a Ceph container in "demo" mode, where a single
+container runs all the required services. This is primarily for
+demonstration purposes and to provide a target for the `ceph_rbd_csi`
+pack.
+
+**NOTE:** This pack is not suitable for production, and if the
+allocation is rescheduled all data written to Ceph will be lost! If
+you are intererested in submitting an update to make this Ceph pack
+production-ready, the Nomad engineering team would enthusiastically
+review it!
+
+## Client Requirements
+
+This pack can only be run on Nomad clients that have enabled volumes
+and privileged mode for the Docker task driver. In addition, you must
+have the `rbd` kernel module loaded:
+
+```
+$ sudo modprobe rbd
+$ lsmod | grep rbd
+rbd                   106496  0
+libceph               327680  1 rbd
+```
+
+Without the kernel module loaded, plugins that consume Ceph will fail
+with errors like: `modprobe: FATAL: Module rbd not found in directory`
+
+## Variables
+
+* `job_name` (string "ceph") - The name to use for the job.
+* `datacenters` (list(string) ["dc1"]) - A list of datacenters in the
+  region which are eligible for task placement.
+* `region` (string "global") - The region where the job should be
+  placed.
+* `ceph_image` (string "ceph/daemon:latest-octopus") - The container
+  image for Ceph.
+* `ceph_cluster_id` (string "") - The Ceph cluster ID (will default to
+  a random UUID).
+* `ceph_demo_uid` (string "demo") - The UID for the Ceph demo.
+* `ceph_demo_bucket` (string "example") - The bucket name for the Ceph demo.
+* `ceph_monitor_service_name` (string "ceph-mon") - The Consul service
+  name for the Ceph monitoring service.
+* `ceph_monitor_service_port` (number 3300) - The port for the Ceph
+  monitoring service to listen on.
+* `ceph_dashboard_service_name` (string "ceph-dashboard") - The Consul
+  service name for the Ceph dashboard service.
+* `ceph_dashboard_service_port` (number 5000) - The port for the Ceph
+  dashboard service to listen on.
+* `ceph_config_file` (string "") - The full text of the Ceph demo
+  configuration file. A reasonable demo will be provided by default.
+
+#### `constraints` List of Objects
+
+[Nomad job specification
+constraints](https://www.nomadproject.io/docs/job-specification/constraint)
+allow restricting the set of eligible nodes on which the tasks will
+run. This pack automatically configures the following required
+constraints:
+
+* The task will run on Linux hosts only
+* The task will run on hosts with the Docker driver's
+  [`volumes`](https://www.nomadproject.io/docs/drivers/docker#volumes-1)
+  enabled and
+  [`allow_privileged`](https://www.nomadproject.io/docs/drivers/docker#allow_privileged)
+  set to `true`.
+
+You can set additional constraints with the `constraints` variable,
+which takes a list of objects with the following fields:
+
+* `attribute` (string) - Specifies the name or reference of the
+  attribute to examine for the constraint.
+* `operator` (string) - Specifies the comparison operator. The
+  ordering is compared lexically.
+* `value` (string) - Specifies the value to compare the attribute
+  against using the specified operation.
+
+Below is also an example of how to pass `constraints` to the CLI with
+with the `-var` argument.
+
+```bash
+nomad-pack run -var 'constraints=[{"attribute":"$${meta.my_custom_value}","operator":">","value":"3"}]' packs/ceph
+```
+
+#### `resources` Object
+
+* `cpu` (number 256) - Specifies the CPU required to run this task in
+  MHz.
+* `memory` (number 600) - Specifies the memory required in MB.

--- a/packs/ceph/config/bad.json
+++ b/packs/ceph/config/bad.json
@@ -1,0 +1,288 @@
+{
+    "Job": {
+        "Affinities": null,
+        "AllAtOnce": false,
+        "Constraints": null,
+        "ConsulNamespace": "",
+        "ConsulToken": "",
+        "CreateIndex": 360,
+        "Datacenters": [
+            "dc1"
+        ],
+        "DispatchIdempotencyToken": "",
+        "Dispatched": false,
+        "ID": "ceph",
+        "JobModifyIndex": 360,
+        "Meta": {
+            "pack.deployment_name": "ceph",
+            "pack.job": "ceph",
+            "pack.name": "ceph",
+            "pack.path": "/Users/timgross/ws/nomad/src/hashicorp/nomad-pack-community-registry/packs/ceph",
+            "pack.registry": "<<local folder>>",
+            "pack.version": "<<none>>"
+        },
+        "Migrate": null,
+        "ModifyIndex": 361,
+        "Multiregion": null,
+        "Name": "ceph",
+        "Namespace": "default",
+        "NomadTokenID": "68b87548-8c4d-e1af-813e-53615828e331",
+        "ParameterizedJob": null,
+        "ParentID": "",
+        "Payload": null,
+        "Periodic": null,
+        "Priority": 50,
+        "Region": "global",
+        "Reschedule": null,
+        "Spreads": null,
+        "Stable": false,
+        "Status": "running",
+        "StatusDescription": "",
+        "Stop": false,
+        "SubmitTime": 1649882213178312545,
+        "TaskGroups": [
+            {
+                "Affinities": null,
+                "Constraints": [
+                    {
+                        "LTarget": "${attr.kernel.name}",
+                        "Operand": "=",
+                        "RTarget": "linux"
+                    },
+                    {
+                        "LTarget": "${attr.driver.docker.privileged.enabled}",
+                        "Operand": "=",
+                        "RTarget": "true"
+                    }
+                ],
+                "Consul": {
+                    "Namespace": ""
+                },
+                "Count": 1,
+                "EphemeralDisk": {
+                    "Migrate": false,
+                    "SizeMB": 300,
+                    "Sticky": false
+                },
+                "MaxClientDisconnect": null,
+                "Meta": null,
+                "Migrate": {
+                    "HealthCheck": "checks",
+                    "HealthyDeadline": 300000000000,
+                    "MaxParallel": 1,
+                    "MinHealthyTime": 10000000000
+                },
+                "Name": "ceph",
+                "Networks": [
+                    {
+                        "CIDR": "",
+                        "DNS": null,
+                        "Device": "",
+                        "DynamicPorts": null,
+                        "Hostname": "",
+                        "IP": "",
+                        "MBits": 0,
+                        "Mode": "host",
+                        "ReservedPorts": null
+                    }
+                ],
+                "ReschedulePolicy": {
+                    "Attempts": 0,
+                    "Delay": 30000000000,
+                    "DelayFunction": "exponential",
+                    "Interval": 0,
+                    "MaxDelay": 3600000000000,
+                    "Unlimited": true
+                },
+                "RestartPolicy": {
+                    "Attempts": 2,
+                    "Delay": 15000000000,
+                    "Interval": 1800000000000,
+                    "Mode": "fail"
+                },
+                "Scaling": null,
+                "Services": [
+                    {
+                        "AddressMode": "auto",
+                        "CanaryMeta": null,
+                        "CanaryTags": null,
+                        "CheckRestart": null,
+                        "Checks": null,
+                        "Connect": null,
+                        "EnableTagOverride": false,
+                        "Id": "",
+                        "Meta": null,
+                        "Name": "ceph-mon",
+                        "OnUpdate": "require_healthy",
+                        "PortLabel": "3300",
+                        "Provider": "consul",
+                        "Tags": null,
+                        "TaskName": ""
+                    },
+                    {
+                        "AddressMode": "auto",
+                        "CanaryMeta": null,
+                        "CanaryTags": null,
+                        "CheckRestart": null,
+                        "Checks": [
+                            {
+                                "AddressMode": "",
+                                "Args": null,
+                                "Body": "",
+                                "CheckRestart": null,
+                                "Command": "",
+                                "Expose": false,
+                                "FailuresBeforeCritical": 0,
+                                "GRPCService": "",
+                                "GRPCUseTLS": false,
+                                "Header": null,
+                                "Id": "",
+                                "InitialStatus": "warning",
+                                "Interval": 5000000000,
+                                "Method": "",
+                                "Name": "service: \"ceph-dashboard\" check",
+                                "OnUpdate": "require_healthy",
+                                "Path": "/",
+                                "PortLabel": "",
+                                "Protocol": "",
+                                "SuccessBeforePassing": 0,
+                                "TLSSkipVerify": false,
+                                "TaskName": "",
+                                "Timeout": 1000000000,
+                                "Type": "http"
+                            }
+                        ],
+                        "Connect": null,
+                        "EnableTagOverride": false,
+                        "Id": "",
+                        "Meta": null,
+                        "Name": "ceph-dashboard",
+                        "OnUpdate": "require_healthy",
+                        "PortLabel": "5000",
+                        "Provider": "consul",
+                        "Tags": null,
+                        "TaskName": ""
+                    }
+                ],
+                "ShutdownDelay": null,
+                "Spreads": null,
+                "StopAfterClientDisconnect": null,
+                "Tasks": [
+                    {
+                        "Affinities": null,
+                        "Artifacts": null,
+                        "Config": {
+                            "mount": [
+                                {
+                                    "source": "local/ceph",
+                                    "target": "/etc/ceph",
+                                    "type": "bind"
+                                }
+                            ],
+                            "network_mode": "host",
+                            "privileged": true,
+                            "args": [
+                                "demo"
+                            ],
+                            "image": "ceph/daemon:latest-octopus"
+                        },
+                        "Constraints": null,
+                        "DispatchPayload": null,
+                        "Driver": "docker",
+                        "Env": null,
+                        "KillSignal": "",
+                        "KillTimeout": 5000000000,
+                        "Kind": "",
+                        "Leader": false,
+                        "Lifecycle": null,
+                        "LogConfig": {
+                            "MaxFileSizeMB": 10,
+                            "MaxFiles": 10
+                        },
+                        "Meta": null,
+                        "Name": "ceph",
+                        "Resources": {
+                            "CPU": 256,
+                            "Cores": 0,
+                            "Devices": null,
+                            "DiskMB": 0,
+                            "IOPS": 0,
+                            "MemoryMB": 512,
+                            "MemoryMaxMB": 0,
+                            "Networks": null
+                        },
+                        "RestartPolicy": {
+                            "Attempts": 2,
+                            "Delay": 15000000000,
+                            "Interval": 1800000000000,
+                            "Mode": "fail"
+                        },
+                        "ScalingPolicies": null,
+                        "Services": null,
+                        "ShutdownDelay": 0,
+                        "Templates": [
+                            {
+                                "ChangeMode": "restart",
+                                "ChangeSignal": "",
+                                "DestPath": "${NOMAD_TASK_DIR}/env",
+                                "EmbeddedTmpl": "MON_IP={{ sockaddr \"with $ifAddrs := GetDefaultInterfaces | include \\\"type\\\" \\\"IPv4\\\" | limit 1 -}}{{- range $ifAddrs -}}{{ attr \\\"address\\\" . }}{{ end }}{{ end \" }}\nCEPH_PUBLIC_NETWORK=0.0.0.0/0\nCEPH_DEMO_UID=demo\nCEPH_DEMO_BUCKET=example\n",
+                                "Envvars": true,
+                                "LeftDelim": "{{",
+                                "Perms": "0644",
+                                "RightDelim": "}}",
+                                "SourcePath": "",
+                                "Splay": 5000000000,
+                                "VaultGrace": 0,
+                                "Wait": null
+                            },
+                            {
+                                "ChangeMode": "restart",
+                                "ChangeSignal": "",
+                                "DestPath": "${NOMAD_TASK_DIR}/ceph/ceph.conf",
+                                "EmbeddedTmpl": "    \n[global]\nfsid = 8df538f0-624d-43a3-a98f-9afb0effa719\nmon initial members = {{ env \"attr.unique.hostname\" }}\nmon host = v2:{{ sockaddr \"with $ifAddrs := GetDefaultInterfaces | include \\\"type\\\" \\\"IPv4\\\" | limit 1 -}}{{- range $ifAddrs -}}{{ attr \\\"address\\\" . }}{{ end }}{{ end \" }}:3300/0\n\nosd crush chooseleaf type = 0\nosd journal size = 100\npublic network = 0.0.0.0/0\ncluster network = 0.0.0.0/0\nosd pool default size = 1\nmon warn on pool no redundancy = false\nosd_memory_target =  939524096\nosd_memory_base = 251947008\nosd_memory_cache_min = 351706112\nosd objectstore = bluestore\n\n[osd.0]\nosd data = /var/lib/ceph/osd/ceph-0\n\n[client.rgw.linux]\nrgw dns name = {{ env \"attr.unique.hostname\" }}\nrgw enable usage log = true\nrgw usage log tick interval = 1\nrgw usage log flush threshold = 1\nrgw usage max shards = 32\nrgw usage max user shards = 1\nlog file = /var/log/ceph/client.rgw.linux.log\nrgw frontends = beast  endpoint=0.0.0.0:8080\n\n\n",
+                                "Envvars": false,
+                                "LeftDelim": "{{",
+                                "Perms": "0644",
+                                "RightDelim": "}}",
+                                "SourcePath": "",
+                                "Splay": 5000000000,
+                                "VaultGrace": 0,
+                                "Wait": null
+                            }
+                        ],
+                        "User": "",
+                        "Vault": null,
+                        "VolumeMounts": null
+                    }
+                ],
+                "Update": {
+                    "AutoPromote": false,
+                    "AutoRevert": false,
+                    "Canary": 0,
+                    "HealthCheck": "checks",
+                    "HealthyDeadline": 300000000000,
+                    "MaxParallel": 1,
+                    "MinHealthyTime": 10000000000,
+                    "ProgressDeadline": 600000000000,
+                    "Stagger": 30000000000
+                },
+                "Volumes": null
+            }
+        ],
+        "Type": "service",
+        "Update": {
+            "AutoPromote": false,
+            "AutoRevert": false,
+            "Canary": 0,
+            "HealthCheck": "",
+            "HealthyDeadline": 0,
+            "MaxParallel": 1,
+            "MinHealthyTime": 0,
+            "ProgressDeadline": 0,
+            "Stagger": 30000000000
+        },
+        "VaultNamespace": "",
+        "VaultToken": "",
+        "Version": 0
+    }
+}

--- a/packs/ceph/config/ceph.conf
+++ b/packs/ceph/config/ceph.conf
@@ -1,0 +1,28 @@
+[global]
+fsid = 2c4ef9a0-f963-4dcf-9944-e1bd71f3fbad
+mon initial members = nomad-client1
+mon host = v2:10.0.2.15:3300/0
+
+osd crush chooseleaf type = 0
+osd journal size = 100
+public network = 0.0.0.0/0
+cluster network = 0.0.0.0/0
+osd pool default size = 1
+mon warn on pool no redundancy = false
+osd_memory_target =  939524096
+osd_memory_base = 251947008
+osd_memory_cache_min = 351706112
+osd objectstore = bluestore
+
+[osd.0]
+osd data = /var/lib/ceph/osd/ceph-0
+
+[client.rgw.linux]
+rgw dns name = nomad-client1
+rgw enable usage log = true
+rgw usage log tick interval = 1
+rgw usage log flush threshold = 1
+rgw usage max shards = 32
+rgw usage max user shards = 1
+log file = /var/log/ceph/client.rgw.linux.log
+rgw frontends = beast  endpoint=0.0.0.0:8080

--- a/packs/ceph/config/good.json
+++ b/packs/ceph/config/good.json
@@ -1,0 +1,270 @@
+{
+    "Job": {
+        "Affinities": null,
+        "AllAtOnce": false,
+        "Constraints": null,
+        "ConsulNamespace": "",
+        "ConsulToken": "",
+        "CreateIndex": 282,
+        "Datacenters": [
+            "dc1"
+        ],
+        "DispatchIdempotencyToken": "",
+        "Dispatched": false,
+        "ID": "ceph",
+        "JobModifyIndex": 338,
+        "Meta": null,
+        "Migrate": null,
+        "ModifyIndex": 339,
+        "Multiregion": null,
+        "Name": "ceph",
+        "Namespace": "default",
+        "NomadTokenID": "68b87548-8c4d-e1af-813e-53615828e331",
+        "ParameterizedJob": null,
+        "ParentID": "",
+        "Payload": null,
+        "Periodic": null,
+        "Priority": 50,
+        "Region": "global",
+        "Reschedule": null,
+        "Spreads": null,
+        "Stable": false,
+        "Status": "running",
+        "StatusDescription": "",
+        "Stop": false,
+        "SubmitTime": 1649882036442626040,
+        "TaskGroups": [
+            {
+                "Affinities": null,
+                "Constraints": null,
+                "Consul": {
+                    "Namespace": ""
+                },
+                "Count": 1,
+                "EphemeralDisk": {
+                    "Migrate": false,
+                    "SizeMB": 300,
+                    "Sticky": false
+                },
+                "MaxClientDisconnect": null,
+                "Meta": null,
+                "Migrate": {
+                    "HealthCheck": "checks",
+                    "HealthyDeadline": 300000000000,
+                    "MaxParallel": 1,
+                    "MinHealthyTime": 10000000000
+                },
+                "Name": "ceph",
+                "Networks": [
+                    {
+                        "CIDR": "",
+                        "DNS": null,
+                        "Device": "",
+                        "DynamicPorts": null,
+                        "Hostname": "",
+                        "IP": "",
+                        "MBits": 0,
+                        "Mode": "host",
+                        "ReservedPorts": null
+                    }
+                ],
+                "ReschedulePolicy": {
+                    "Attempts": 0,
+                    "Delay": 30000000000,
+                    "DelayFunction": "exponential",
+                    "Interval": 0,
+                    "MaxDelay": 3600000000000,
+                    "Unlimited": true
+                },
+                "RestartPolicy": {
+                    "Attempts": 2,
+                    "Delay": 15000000000,
+                    "Interval": 1800000000000,
+                    "Mode": "fail"
+                },
+                "Scaling": null,
+                "Services": [
+                    {
+                        "AddressMode": "auto",
+                        "CanaryMeta": null,
+                        "CanaryTags": null,
+                        "CheckRestart": null,
+                        "Checks": null,
+                        "Connect": null,
+                        "EnableTagOverride": false,
+                        "Id": "",
+                        "Meta": null,
+                        "Name": "ceph-mon",
+                        "OnUpdate": "require_healthy",
+                        "PortLabel": "3300",
+                        "Provider": "consul",
+                        "Tags": null,
+                        "TaskName": ""
+                    },
+                    {
+                        "AddressMode": "auto",
+                        "CanaryMeta": null,
+                        "CanaryTags": null,
+                        "CheckRestart": null,
+                        "Checks": [
+                            {
+                                "AddressMode": "",
+                                "Args": null,
+                                "Body": "",
+                                "CheckRestart": null,
+                                "Command": "",
+                                "Expose": false,
+                                "FailuresBeforeCritical": 0,
+                                "GRPCService": "",
+                                "GRPCUseTLS": false,
+                                "Header": null,
+                                "Id": "",
+                                "InitialStatus": "warning",
+                                "Interval": 5000000000,
+                                "Method": "",
+                                "Name": "service: \"ceph-dashboard\" check",
+                                "OnUpdate": "require_healthy",
+                                "Path": "/",
+                                "PortLabel": "",
+                                "Protocol": "",
+                                "SuccessBeforePassing": 0,
+                                "TLSSkipVerify": false,
+                                "TaskName": "",
+                                "Timeout": 1000000000,
+                                "Type": "http"
+                            }
+                        ],
+                        "Connect": null,
+                        "EnableTagOverride": false,
+                        "Id": "",
+                        "Meta": null,
+                        "Name": "ceph-dashboard",
+                        "OnUpdate": "require_healthy",
+                        "PortLabel": "5000",
+                        "Provider": "consul",
+                        "Tags": null,
+                        "TaskName": ""
+                    }
+                ],
+                "ShutdownDelay": null,
+                "Spreads": null,
+                "StopAfterClientDisconnect": null,
+                "Tasks": [
+                    {
+                        "Affinities": null,
+                        "Artifacts": null,
+                        "Config": {
+                            "args": [
+                                "demo"
+                            ],
+                            "image": "ceph/daemon:latest-octopus",
+                            "mount": [
+                                {
+                                    "source": "local/ceph",
+                                    "target": "/etc/ceph",
+                                    "type": "bind"
+                                }
+                            ],
+                            "network_mode": "host",
+                            "privileged": true
+                        },
+                        "Constraints": null,
+                        "DispatchPayload": null,
+                        "Driver": "docker",
+                        "Env": null,
+                        "KillSignal": "",
+                        "KillTimeout": 5000000000,
+                        "Kind": "",
+                        "Leader": false,
+                        "Lifecycle": null,
+                        "LogConfig": {
+                            "MaxFileSizeMB": 10,
+                            "MaxFiles": 10
+                        },
+                        "Meta": null,
+                        "Name": "ceph",
+                        "Resources": {
+                            "CPU": 256,
+                            "Cores": 0,
+                            "Devices": null,
+                            "DiskMB": 0,
+                            "IOPS": 0,
+                            "MemoryMB": 512,
+                            "MemoryMaxMB": 0,
+                            "Networks": null
+                        },
+                        "RestartPolicy": {
+                            "Attempts": 2,
+                            "Delay": 15000000000,
+                            "Interval": 1800000000000,
+                            "Mode": "fail"
+                        },
+                        "ScalingPolicies": null,
+                        "Services": null,
+                        "ShutdownDelay": 0,
+                        "Templates": [
+                            {
+                                "ChangeMode": "restart",
+                                "ChangeSignal": "",
+                                "DestPath": "${NOMAD_TASK_DIR}/env",
+                                "EmbeddedTmpl": "MON_IP={{ sockaddr \"with $ifAddrs := GetDefaultInterfaces | include \\\"type\\\" \\\"IPv4\\\" | limit 1 -}}{{- range $ifAddrs -}}{{ attr \\\"address\\\" . }}{{ end }}{{ end \" }}\nCEPH_PUBLIC_NETWORK=0.0.0.0/0\nCEPH_DEMO_UID=demo\nCEPH_DEMO_BUCKET=foobar\n",
+                                "Envvars": true,
+                                "LeftDelim": "{{",
+                                "Perms": "0644",
+                                "RightDelim": "}}",
+                                "SourcePath": "",
+                                "Splay": 5000000000,
+                                "VaultGrace": 0,
+                                "Wait": null
+                            },
+                            {
+                                "ChangeMode": "restart",
+                                "ChangeSignal": "",
+                                "DestPath": "${NOMAD_TASK_DIR}/ceph/ceph.conf",
+                                "EmbeddedTmpl": "[global]\nfsid = e9ba69fa-67ff-5920-b374-84d5801edd19\nmon initial members = linux\nmon host = v2:{{ sockaddr \"with $ifAddrs := GetDefaultInterfaces | include \\\"type\\\" \\\"IPv4\\\" | limit 1 -}}{{- range $ifAddrs -}}{{ attr \\\"address\\\" . }}{{ end }}{{ end \" }}:3300/0\n\nosd crush chooseleaf type = 0\nosd journal size = 100\npublic network = 0.0.0.0/0\ncluster network = 0.0.0.0/0\nosd pool default size = 1\nmon warn on pool no redundancy = false\nosd_memory_target =  939524096\nosd_memory_base = 251947008\nosd_memory_cache_min = 351706112\nosd objectstore = bluestore\n\n[osd.0]\nosd data = /var/lib/ceph/osd/ceph-0\n\n\n[client.rgw.linux]\nrgw dns name = linux\nrgw enable usage log = true\nrgw usage log tick interval = 1\nrgw usage log flush threshold = 1\nrgw usage max shards = 32\nrgw usage max user shards = 1\nlog file = /var/log/ceph/client.rgw.linux.log\nrgw frontends = beast  endpoint=0.0.0.0:8080\n\n",
+                                "Envvars": false,
+                                "LeftDelim": "{{",
+                                "Perms": "0644",
+                                "RightDelim": "}}",
+                                "SourcePath": "",
+                                "Splay": 5000000000,
+                                "VaultGrace": 0,
+                                "Wait": null
+                            }
+                        ],
+                        "User": "",
+                        "Vault": null,
+                        "VolumeMounts": null
+                    }
+                ],
+                "Update": {
+                    "AutoPromote": false,
+                    "AutoRevert": false,
+                    "Canary": 0,
+                    "HealthCheck": "checks",
+                    "HealthyDeadline": 300000000000,
+                    "MaxParallel": 1,
+                    "MinHealthyTime": 10000000000,
+                    "ProgressDeadline": 600000000000,
+                    "Stagger": 30000000000
+                },
+                "Volumes": null
+            }
+        ],
+        "Type": "service",
+        "Update": {
+            "AutoPromote": false,
+            "AutoRevert": false,
+            "Canary": 0,
+            "HealthCheck": "",
+            "HealthyDeadline": 0,
+            "MaxParallel": 1,
+            "MinHealthyTime": 0,
+            "ProgressDeadline": 0,
+            "Stagger": 30000000000
+        },
+        "VaultNamespace": "",
+        "VaultToken": "",
+        "Version": 2
+    }
+}

--- a/packs/ceph/config/stdout.log
+++ b/packs/ceph/config/stdout.log
@@ -1,0 +1,16 @@
+$ nomad alloc logs 905
+creating /etc/ceph/ceph.client.admin.keyring
+creating /etc/ceph/ceph.mon.keyring
+monmaptool: monmap file /etc/ceph/monmap-ceph
+monmaptool: set fsid to 0ff381d1-8108-4a7d-ad13-1fa446063f39
+monmaptool: writing epoch 0 to /etc/ceph/monmap-ceph (1 monitors)
+importing contents of /etc/ceph/ceph.client.admin.keyring into /etc/ceph/ceph.mon.keyring
+2022-04-13 19:57:52  /opt/ceph-container/bin/entrypoint.sh: I can see existing Ceph files, please remove them!
+2022-04-13 19:57:52  /opt/ceph-container/bin/entrypoint.sh: To run the demo container, remove the content of /var/lib/ceph/ and /etc/ceph/
+2022-04-13 19:57:52  /opt/ceph-container/bin/entrypoint.sh: Before doing this, make sure you are removing any sensitive data.
+2022-04-13 19:58:09  /opt/ceph-container/bin/entrypoint.sh: I can see existing Ceph files, please remove them!
+2022-04-13 19:58:09  /opt/ceph-container/bin/entrypoint.sh: To run the demo container, remove the content of /var/lib/ceph/ and /etc/ceph/
+2022-04-13 19:58:09  /opt/ceph-container/bin/entrypoint.sh: Before doing this, make sure you are removing any sensitive data.
+
+$ nomad alloc logs -stderr 905
+global_init: error reading config file.

--- a/packs/ceph/metadata.hcl
+++ b/packs/ceph/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = "https://github.com/ceph/ceph-container"
+  author = "Tim Gross <tgross@hashicorp.com>"
+}
+
+pack {
+  name        = "ceph"
+  description = "This pack deploys Ceph in demo mode"
+  url         = "https://github.com/hashicorp/nomad-pack-community-registry/ceph"
+  version     = "0.1.0"
+}

--- a/packs/ceph/outputs.tpl
+++ b/packs/ceph/outputs.tpl
@@ -1,0 +1,18 @@
+For the Ceph RBD CSI pack, you'll need the ceph_cluster_id and
+ceph_monitor_service_name variables. If you haven't set ceph_cluster_id, it
+will have been automatically generated and you can find it in the Ceph
+allocation file system. Get the "fsid" value here:
+
+    nomad alloc fs :alloc_id ceph/local/ceph/ceph.conf | awk -F' = ' '/fsid/{print $2}'
+
+To create volumes, you'll need the client.admin key value from the Ceph mon
+keyring. Read that with:
+
+   nomad alloc fs :alloc_id ceph/local/ceph/ceph.mon.keyring
+
+You'll set this value in the volume secrets block. For example:
+
+secrets {
+  userID  = "admin"
+  userKey = "AQDsIoxgHqpe..ZdIzA=="
+}

--- a/packs/ceph/templates/_config.tpl
+++ b/packs/ceph/templates/_config.tpl
@@ -1,0 +1,33 @@
+[[- define "config_file" -]]
+[[- if .my.ceph_config_file -]]
+[[ .my.ceph_config_file ]]
+[[ else ]][global]
+fsid = [[ if .my.ceph_cluster_id ]][[ .my.ceph_cluster_id ]][[ else ]][[ uuidv4 ]][[ end ]]
+mon initial members = {{ env "attr.unique.hostname" }}
+mon host = v2:{{ sockaddr "with $ifAddrs := GetDefaultInterfaces | include \"type\" \"IPv4\" | limit 1 -}}{{- range $ifAddrs -}}{{ attr \"address\" . }}{{ end }}{{ end " }}:[[ .my.ceph_monitor_port ]]/0
+
+osd crush chooseleaf type = 0
+osd journal size = 100
+public network = 0.0.0.0/0
+cluster network = 0.0.0.0/0
+osd pool default size = 1
+mon warn on pool no redundancy = false
+osd_memory_target =  939524096
+osd_memory_base = 251947008
+osd_memory_cache_min = 351706112
+osd objectstore = bluestore
+
+[osd.0]
+osd data = /var/lib/ceph/osd/ceph-0
+
+[client.rgw.linux]
+rgw dns name = {{ env "attr.unique.hostname" }}
+rgw enable usage log = true
+rgw usage log tick interval = 1
+rgw usage log flush threshold = 1
+rgw usage max shards = 32
+rgw usage max user shards = 1
+log file = /var/log/ceph/client.rgw.linux.log
+rgw frontends = beast  endpoint=0.0.0.0:8080
+[[ end ]]
+[[ end ]]

--- a/packs/ceph/templates/_constraints.tpl
+++ b/packs/ceph/templates/_constraints.tpl
@@ -9,7 +9,7 @@
       value     = true
     }
 
-[[- if .my.constraints -]][[ range $idx, $constraint := .my.constraints ]]
+[[ range $idx, $constraint := .my.constraints ]]
     constraint {
       attribute = [[ $constraint.attribute | quote ]]
   [[- if $constraint.value ]]
@@ -19,4 +19,4 @@
       operator  = [[ $constraint.operator | quote ]]
   [[- end ]]
     }
-[[- end ]][[- end -]][[- end ]]
+[[- end ]][[- end ]]

--- a/packs/ceph/templates/_constraints.tpl
+++ b/packs/ceph/templates/_constraints.tpl
@@ -1,0 +1,22 @@
+[[ define "constraints" ]]
+    constraint {
+      attribute = "${attr.kernel.name}"
+      value     = "linux"
+    }
+
+    constraint {
+      attribute = "${attr.driver.docker.privileged.enabled}"
+      value     = true
+    }
+
+[[- if .my.constraints -]][[ range $idx, $constraint := .my.constraints ]]
+    constraint {
+      attribute = [[ $constraint.attribute | quote ]]
+  [[- if $constraint.value ]]
+      value     = [[ $constraint.value | quote ]]
+  [[- end ]]
+      [[- if $constraint.operator  ]]
+      operator  = [[ $constraint.operator | quote ]]
+  [[- end ]]
+    }
+[[- end ]][[- end -]][[- end ]]

--- a/packs/ceph/templates/_location.tpl
+++ b/packs/ceph/templates/_location.tpl
@@ -1,0 +1,5 @@
+[[- define "location" ]]
+  namespace   = "[[ .my.namespace ]]"
+  region      = "[[ .my.region ]]"
+  datacenters = [[ .my.datacenters | toJson ]]
+[[- end -]]

--- a/packs/ceph/templates/_resources.tpl
+++ b/packs/ceph/templates/_resources.tpl
@@ -1,0 +1,6 @@
+[[- define "resources" ]]
+      resources {
+        cpu    = [[ .my.resources.cpu ]]
+        memory = [[ .my.resources.memory ]]
+      }
+[[- end -]]

--- a/packs/ceph/templates/ceph.nomad.tpl
+++ b/packs/ceph/templates/ceph.nomad.tpl
@@ -1,0 +1,79 @@
+job "[[ .my.job_name ]]" {
+
+  [[- template "location" . ]]
+
+  group "ceph" {
+
+    [[- template "constraints" . ]]
+
+    network {
+      # we can't configure networking in a way that will both satisfy the Ceph
+      # monitor's requirement to know its own IP address *and* be routable
+      # between containers, without either CNI or fixing
+      # https://github.com/hashicorp/nomad/issues/9781
+      #
+      # So for now we'll use host networking to keep this demo understandable.
+      # That also means the controller plugin will need to use host addresses.
+      mode = "host"
+    }
+
+    service {
+      name = "[[ .my.ceph_monitor_service_name ]]"
+      port = [[ .my.ceph_monitor_port ]]
+    }
+
+    service {
+      name = "[[ .my.ceph_dashboard_service_name ]]"
+      port = [[ .my.ceph_dashboard_port ]]
+
+      check {
+        type           = "http"
+        interval       = "5s"
+        timeout        = "1s"
+        path           = "/"
+        initial_status = "warning"
+      }
+    }
+
+    task "ceph" {
+      driver = "docker"
+
+      config {
+        image        = "[[ .my.ceph_image ]]"
+        args         = ["demo"]
+        network_mode = "host"
+        privileged   = true
+
+        mount {
+          type   = "bind"
+          source = "local/ceph"
+          target = "/etc/ceph"
+        }
+      }
+
+      [[- template "resources" . ]]
+
+      template {
+
+        data = <<EOT
+MON_IP={{ sockaddr "with $ifAddrs := GetDefaultInterfaces | include \"type\" \"IPv4\" | limit 1 -}}{{- range $ifAddrs -}}{{ attr \"address\" . }}{{ end }}{{ end " }}
+CEPH_PUBLIC_NETWORK=0.0.0.0/0
+CEPH_DEMO_UID=[[ .my.ceph_demo_uid ]]
+CEPH_DEMO_BUCKET=[[ .my.ceph_demo_bucket ]]
+EOT
+
+        destination = "${NOMAD_TASK_DIR}/env"
+        env         = true
+      }
+
+      template {
+
+        data        = <<EOT
+[[ template "config_file" . ]]
+EOT
+
+        destination = "${NOMAD_TASK_DIR}/ceph/ceph.conf"
+      }
+    }
+  }
+}

--- a/packs/ceph/variables.hcl
+++ b/packs/ceph/variables.hcl
@@ -1,0 +1,99 @@
+variable "job_name" {
+  description = "The name of the Ceph job."
+  type        = string
+  default     = "ceph"
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement."
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "region" {
+  description = "The region where the job should be placed."
+  type        = string
+  default     = "global"
+}
+
+variable "namespace" {
+  description = "The namespace for the job."
+  type        = string
+  default     = "default"
+}
+
+variable "ceph_image" {
+  description = "The container image for Ceph."
+  type        = string
+  default     = "ceph/daemon:latest-octopus"
+}
+
+variable "ceph_cluster_id" {
+  description = "The Ceph cluster ID (will default to a random UUID)."
+  type        = string
+  default     = ""
+}
+
+variable "ceph_demo_uid" {
+  description = "The UID for the Ceph demo."
+  type        = string
+  default     = "demo"
+}
+
+variable "ceph_demo_bucket" {
+  description = "The bucket name for the Ceph demo."
+  type        = string
+  default     = "example"
+}
+
+variable "ceph_monitor_service_name" {
+  description = "The Consul service name for the Ceph monitoring service."
+  type        = string
+  default     = "ceph-mon"
+}
+
+variable "ceph_monitor_port" {
+  description = "The port for the Ceph monitoring service to listen on."
+  type        = number
+  default     = 3300
+}
+
+variable "ceph_dashboard_service_name" {
+  description = "The Consul service name for the Ceph dashboard service."
+  type        = string
+  default     = "ceph-dashboard"
+}
+
+variable "ceph_dashboard_port" {
+  description = "The port for the Ceph dashboard to listen on."
+  type        = number
+  default     = 5000
+}
+
+variable "ceph_config_file" {
+  description = "The full text of the Ceph demo configuration file. A reasonable demo will be provided by default."
+  type        = string
+  default     = ""
+}
+
+variable "constraints" {
+  description = "Additional constraints to apply to the job."
+  type = list(object({
+    attribute = string
+    operator  = string
+    value     = string
+  }))
+  default = []
+}
+
+variable "resources" {
+  description = "The resources to assign to the task."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 256,
+    memory = 600 # ceph is hungry!
+  }
+}

--- a/packs/ceph_rbd_csi/CHANGELOG.md
+++ b/packs/ceph_rbd_csi/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0
+
+- Initial release

--- a/packs/ceph_rbd_csi/README.md
+++ b/packs/ceph_rbd_csi/README.md
@@ -1,0 +1,91 @@
+# ceph_rbd_csi
+
+This pack deploys two jobs that run the [Ceph
+RBD](https://github.com/ceph/ceph-csi) CSI plugin. The node plugin
+tasks will be run as a system job, and the controller tasks will be
+run as a service job.
+
+## Client Requirements
+
+This pack can only be run on Nomad clients that have enabled volumes
+and privileged mode for the Docker task driver. In addition, you must
+have the `rbd` kernel module loaded:
+
+```
+$ sudo modprobe rbd
+$ lsmod | grep rbd
+rbd                   106496  0
+libceph               327680  1 rbd
+```
+
+Without the kernel module loaded, plugins tasks will fail with errors
+like: `modprobe: FATAL: Module rbd not found in directory`
+
+## Variables
+
+* `job_name` (string "ceph_rbd_csi") - The prefix to use as the job
+  name for the plugins. For exmaple, if `job_name = "ceph_rbd_csi"`,
+  the plugin job will be named `ceph_rbd_csi_controller`.
+* `datacenters` (list(string) ["dc1"]) - A list of datacenters in the
+  region which are eligible for task placement.
+* `region` (string "global") - The region where the job should be
+  placed.
+* `plugin_id` (string "rbd.csi.ceph.com") - The ID to register
+  in Nomad for the plugin.
+* `plugin_namespace` (string "default") - The namespace for the plugin
+  job.
+* `plugin_image` (string "quay.io/cephcsi/cephcsi:canary") - The
+  container image for the plugin.
+* `controller_count` (number 2) - The number of controller instances
+  to be deployed (at least 2 recommended).
+* `ceph_cluster_id` (string "") - The Ceph cluster ID.
+* `ceph_monitor_service_name` (string "ceph-mon") - The Consul service
+  name for the Ceph monitoring service.
+* `volume_id` (string "myvolume") - ID for the example volume spec to
+  output.
+* `volume_namespace` (string "default") - Namespace for the example
+  volume spec to output.
+* `volume_min_capacity` (string "10GiB") - Minimum capacity for the
+  example volume spec to output.
+* `volume_max_capacity` (string "30GiB") - Maximum capacity for the
+  example volume spec to output.
+
+## Volume creation
+
+This pack outputs an example volume specification based on the plugin variables.
+
+#### **`volume.hcl`**
+
+```
+id        = "myvolume"
+name      = "myvolume"
+namespace = "default"
+type      = "csi"
+plugin_id = "rbd.csi.ceph.com"
+
+capacity_min = "10GiB"
+capacity_max = "30GiB"
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "block-device"
+}
+
+# get this secret from the Ceph allocation:
+# /etc/ceph/ceph.client.admin.keyring
+secrets {
+  userID  = "admin"
+  userKey = "AQDsIoxgHqpe...spTbvwZdIzA=="
+}
+
+parameters {
+  clusterID     = "129ceb60-ae2e-4313-a9f8-cb6087f97787"
+  pool          = "rbd"
+  imageFeatures = "layering"
+}
+```

--- a/packs/ceph_rbd_csi/metadata.hcl
+++ b/packs/ceph_rbd_csi/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = "https://github.com/ceph/ceph-csi"
+  author = "Tim Gross <tgross@hashicorp.com>"
+}
+
+pack {
+  name        = "ceph_rbd_csi"
+  description = "This pack deploys the Ceph RBD CSI plugin"
+  url         = "https://github.com/hashicorp/nomad-pack-community-registry/ceph_rbd_csi"
+  version     = "0.1.0"
+}

--- a/packs/ceph_rbd_csi/outputs.tpl
+++ b/packs/ceph_rbd_csi/outputs.tpl
@@ -1,0 +1,31 @@
+id        = "[[ .my.volume_id ]]"
+name      = "[[ .my.volume_id ]]"
+namespace = "[[ .my.volume_namespace ]]"
+type      = "csi"
+plugin_id = "[[ .my.plugin_id ]]"
+
+capacity_min = "[[ .my.volume_min_capacity ]]"
+capacity_max = "[[ .my.volume_max_capacity ]]"
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "single-node-writer"
+  attachment_mode = "block-device"
+}
+
+# get this secret from the Ceph allocation:
+# /etc/ceph/ceph.client.admin.keyring
+secrets {
+  userID  = "admin"
+  userKey = "AQDsIoxgHqpe...spTbvwZdIzA=="
+}
+
+parameters {
+  clusterID     = "[[ .my.ceph_cluster_id ]]"
+  pool          = "rbd"
+  imageFeatures = "layering"
+}

--- a/packs/ceph_rbd_csi/templates/_constraints.tpl
+++ b/packs/ceph_rbd_csi/templates/_constraints.tpl
@@ -1,0 +1,18 @@
+[[ define "constraints" ]]
+    constraint {
+      attribute = "${attr.kernel.name}"
+      value     = "linux"
+    }
+
+[[- if .my.constraints -]][[ range $idx, $constraint := .my.constraints ]]
+    constraint {
+      attribute = [[ $constraint.attribute | quote ]]
+  [[- if $constraint.value ]]
+      value     = [[ $constraint.value | quote ]]
+  [[- end ]]
+      [[- if $constraint.operator  ]]
+      operator  = [[ $constraint.operator | quote ]]
+  [[- end ]]
+    }
+[[- end ]][[- end ]]
+[[- end -]]

--- a/packs/ceph_rbd_csi/templates/_constraints.tpl
+++ b/packs/ceph_rbd_csi/templates/_constraints.tpl
@@ -4,7 +4,7 @@
       value     = "linux"
     }
 
-[[- if .my.constraints -]][[ range $idx, $constraint := .my.constraints ]]
+[[ range $idx, $constraint := .my.constraints ]]
     constraint {
       attribute = [[ $constraint.attribute | quote ]]
   [[- if $constraint.value ]]
@@ -15,4 +15,3 @@
   [[- end ]]
     }
 [[- end ]][[- end ]]
-[[- end -]]

--- a/packs/ceph_rbd_csi/templates/_location.tpl
+++ b/packs/ceph_rbd_csi/templates/_location.tpl
@@ -1,0 +1,5 @@
+[[- define "location" -]]
+  namespace   = "[[ .my.plugin_namespace ]]"
+  region      = "[[ .my.region ]]"
+  datacenters = [[ .my.datacenters | toJson ]]
+[[- end -]]

--- a/packs/ceph_rbd_csi/templates/_resources.tpl
+++ b/packs/ceph_rbd_csi/templates/_resources.tpl
@@ -1,0 +1,6 @@
+[[- define "resources" ]]
+      resources {
+        cpu    = [[ .my.resources.cpu ]]
+        memory = [[ .my.resources.memory ]]
+      }
+[[- end -]]

--- a/packs/ceph_rbd_csi/templates/controller.nomad.tpl
+++ b/packs/ceph_rbd_csi/templates/controller.nomad.tpl
@@ -1,0 +1,90 @@
+job "[[ .my.job_name ]]_controller" {
+
+  [[ template "location" . ]]
+
+  group "controllers" {
+    [[ template "constraints" . ]]
+
+    network {
+      port "prometheus" {}
+    }
+
+    service {
+      name = "[[ .my.prometheus_service_name ]]"
+      port = "prometheus"
+      tags = [[ .my.prometheus_service_tags | toJson ]]
+    }
+
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image = "[[ .my.plugin_image ]]"
+
+        args = [
+          "--drivername=[[ .my.plugin_id ]]",
+          "--v=5",
+          "--type=rbd",
+          "--controllerserver=true",
+          "--nodeid=${NODE_ID}",
+          "--instanceid=${POD_ID}",
+          "--endpoint=${CSI_ENDPOINT}",
+          "--metricsport=${NOMAD_PORT_prometheus}",
+        ]
+
+        ports      = ["prometheus"]
+
+        # we need to be able to write key material to disk in this location
+        mount {
+          type     = "bind"
+          source   = "secrets"
+          target   = "/tmp/csi/keys"
+          readonly = false
+        }
+
+        mount {
+          type     = "bind"
+          source   = "ceph-csi-config/config.json"
+          target   = "/etc/ceph-csi-config/config.json"
+          readonly = false
+        }
+
+      }
+
+      template {
+        data = <<-EOT
+POD_ID=${NOMAD_ALLOC_ID}
+NODE_ID=${node.unique.id}
+CSI_ENDPOINT=unix://csi/csi.sock
+EOT
+
+        destination = "${NOMAD_TASK_DIR}/env"
+        env         = true
+      }
+
+      # ceph configuration file
+      template {
+
+        data = <<EOF
+[{
+    "clusterID": "[[ .my.ceph_cluster_id ]]",
+    "monitors": [
+        {{range $index, $service := service "[[ .my.ceph_monitor_service_name ]]"}}{{if gt $index 0}}, {{end}}"{{.Address}}"{{end}}
+    ]
+}]
+EOF
+
+        destination = "ceph-csi-config/config.json"
+      }
+
+      csi_plugin {
+        id        = "[[ .my.plugin_id ]]"
+        type      = "controller"
+        mount_dir = "/csi"
+      }
+
+      [[- template "resources" . ]]
+
+    }
+  }
+}

--- a/packs/ceph_rbd_csi/templates/node.nomad.tpl
+++ b/packs/ceph_rbd_csi/templates/node.nomad.tpl
@@ -1,0 +1,66 @@
+job "[[ .my.job_name ]]_node" {
+  # you can run node plugins as service jobs as well, but this ensures
+  # that all nodes in the DC have a copy.
+  type = "system"
+  [[ template "location" . ]]
+
+  group "nodes" {
+    [[ template "constraints" . ]]
+    constraint {
+      attribute = "${attr.driver.docker.privileged.enabled}"
+      value     = true
+    }
+
+    network {
+      port "prometheus" {}
+    }
+
+    service {
+      name = "[[ .my.prometheus_service_name ]]"
+      port = "prometheus"
+      tags = [[ .my.prometheus_service_tags | toJson ]]
+    }
+
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image = "[[ .my.plugin_image ]]"
+
+        args = [
+          "--drivername=[[ .my.plugin_id ]]",
+          "--v=5",
+          "--type=rbd",
+          "--nodeserver=true",
+          "--nodeid=${NODE_ID}",
+          "--instanceid=${POD_ID}",
+          "--endpoint=${CSI_ENDPOINT}",
+          "--metricsport=${NOMAD_PORT_prometheus}",
+        ]
+
+        privileged = true
+        ports      = ["prometheus"]
+      }
+
+      template {
+        data = <<-EOT
+POD_ID=${NOMAD_ALLOC_ID}
+NODE_ID=${node.unique.id}
+CSI_ENDPOINT=unix://csi/csi.sock
+EOT
+
+        destination = "${NOMAD_TASK_DIR}/env"
+        env         = true
+      }
+
+      csi_plugin {
+        id        = "[[ .my.plugin_id ]]"
+        type      = "node"
+        mount_dir = "/csi"
+      }
+
+      [[- template "resources" . ]]
+
+    }
+  }
+}

--- a/packs/ceph_rbd_csi/variables.hcl
+++ b/packs/ceph_rbd_csi/variables.hcl
@@ -1,0 +1,112 @@
+variable "job_name" {
+  description = "The prefix to use as the job name for the plugins (ex. ceph_rbd_controller for the controller)."
+  type        = string
+  default     = "ceph_rbd"
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement."
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "region" {
+  description = "The region where the job should be placed."
+  type        = string
+  default     = "global"
+}
+
+variable "plugin_id" {
+  description = "The ID to register in Nomad for the plugin."
+  type        = string
+  default     = "rbd.csi.ceph.com"
+}
+
+variable "plugin_namespace" {
+  description = "The namespace for the plugin job."
+  type        = string
+  default     = "default"
+}
+
+# note: there's no "latest" published for this image
+variable "plugin_image" {
+  description = "The container image for the plugin."
+  type        = string
+  default     = "quay.io/cephcsi/cephcsi:canary"
+}
+
+variable "controller_count" {
+  description = "The number of controller instances to be deployed (at least 2 recommended)."
+  type        = number
+  default     = 2
+}
+
+variable "constraints" {
+  description = "Additional constraints to apply to the jobs."
+  type = list(object({
+    attribute = string
+    operator  = string
+    value     = string
+  }))
+  default = []
+}
+
+variable "resources" {
+  description = "The resources to assign to the plugin tasks."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 256,
+    memory = 256
+  }
+}
+
+variable "ceph_cluster_id" {
+  description = "The Ceph cluster ID (required)."
+  type        = string
+  default     = ""
+}
+
+variable "ceph_monitor_service_name" {
+  description = "The Consul service name for the Ceph monitoring service."
+  type        = string
+  default     = "ceph-mon"
+}
+
+variable "prometheus_service_name" {
+  description = "The Consul service name for prometheus monitoring."
+  type        = string
+  default     = "prometheus"
+}
+
+variable "prometheus_service_tags" {
+  description = "The Consul service tags for prometheus monitoring."
+  type        = list(string)
+  default     = ["ceph-csi"]
+}
+
+variable "volume_id" {
+  description = "ID for the example volume spec to output."
+  type        = string
+  default     = "myvolume"
+}
+
+variable "volume_namespace" {
+  description = "Namespace for the example volume spec to output."
+  type        = string
+  default     = "default"
+}
+
+variable "volume_min_capacity" {
+  description = "Minimum capacity for the example volume spec to output."
+  type        = string
+  default     = "10GiB"
+}
+
+variable "volume_max_capacity" {
+  description = "Maximum capacity for the example volume spec to output."
+  type        = string
+  default     = "30GiB"
+}


### PR DESCRIPTION
A pack for deploying the Ceph RBD CSI plugin and a Ceph demo

Example runs in my Vagrant cluster environment:

<details><summary>render ceph output</summary>

```
$ nomad-pack render ceph
ceph/ceph.nomad:

job "ceph" {
  namespace   = "default"
  region      = "global"
  datacenters = ["dc1"]

  group "ceph" {
    constraint {
      attribute = "${attr.kernel.name}"
      value     = "linux"
    }

    constraint {
      attribute = "${attr.driver.docker.privileged.enabled}"
      value     = true
    }

    network {
      # we can't configure networking in a way that will both satisfy the Ceph
      # monitor's requirement to know its own IP address *and* be routable
      # between containers, without either CNI or fixing
      # https://github.com/hashicorp/nomad/issues/9781
      #
      # So for now we'll use host networking to keep this demo understandable.
      # That also means the controller plugin will need to use host addresses.
      mode = "host"
    }

    service {
      name = "ceph-mon"
      port = 3300
    }

    service {
      name = "ceph-dashboard"
      port = 5000

      check {
        type           = "http"
        interval       = "5s"
        timeout        = "1s"
        path           = "/"
        initial_status = "warning"
      }
    }

    task "ceph" {
      driver = "docker"

      config {
        image        = "ceph/daemon:latest-octopus"
        args         = ["demo"]
        network_mode = "host"
        privileged   = true

        mount {
          type   = "bind"
          source = "local/ceph"
          target = "/etc/ceph"
        }
      }
      resources {
        cpu    = 256
        memory = 600
      }

      template {

        data = <<EOT
MON_IP={{ sockaddr "with $ifAddrs := GetDefaultInterfaces | include \"type\" \"IPv4\" | limit 1 -}}{{-
range $ifAddrs -}}{{ attr \"address\" . }}{{ end }}{{ end " }}
CEPH_PUBLIC_NETWORK=0.0.0.0/0
CEPH_DEMO_UID=demo
CEPH_DEMO_BUCKET=example
EOT

        destination = "${NOMAD_TASK_DIR}/env"
        env         = true
      }

      template {

        data        = <<EOT
[global]
fsid = eb34e46e-90c1-4a72-932e-5c305c31e1ed
mon initial members = {{ env "attr.unique.hostname" }}
mon host = v2:{{ sockaddr "with $ifAddrs := GetDefaultInterfaces | include \"type\" \"IPv4\" | limit 1
-}}{{- range $ifAddrs -}}{{ attr \"address\" . }}{{ end }}{{ end " }}:3300/0

osd crush chooseleaf type = 0
osd journal size = 100
public network = 0.0.0.0/0
cluster network = 0.0.0.0/0
osd pool default size = 1
mon warn on pool no redundancy = false
osd_memory_target =  939524096
osd_memory_base = 251947008
osd_memory_cache_min = 351706112
osd objectstore = bluestore

[osd.0]
osd data = /var/lib/ceph/osd/ceph-0

[client.rgw.linux]
rgw dns name = {{ env "attr.unique.hostname" }}
rgw enable usage log = true
rgw usage log tick interval = 1
rgw usage log flush threshold = 1
rgw usage max shards = 32
rgw usage max user shards = 1
log file = /var/log/ceph/client.rgw.linux.log
rgw frontends = beast  endpoint=0.0.0.0:8080


EOT

        destination = "${NOMAD_TASK_DIR}/ceph/ceph.conf"
      }
    }
  }
}
```

</details>

<details><summary>run ceph output</summary>

```
$ nomad-pack run ./ceph
  Evaluation ID: 497970f1-684f-d89d-4e8e-f5c4ccd221f3
  Job 'ceph' in pack deployment 'ceph' registered successfully
Pack successfully deployed. Use ./ceph to manage this this deployed instance with plan, stop,
destroy, or info

For the Ceph RBD CSI pack, you'll need the ceph_cluster_id and
ceph_monitor_service_name variables. If you haven't set ceph_cluster_id, it
will have been automatically generated and you can find it in the Ceph
allocation file system. Get the "fsid" value here:

    nomad alloc fs :alloc_id ceph/local/ceph/ceph.conf | awk -F' = ' '/fsid/{print $2}'

To create volumes, you'll need the client.admin key value from the Ceph mon
keyring. Read that with:

   nomad alloc fs :alloc_id ceph/local/ceph/ceph.mon.keyring

You'll set this value in the volume secrets block. For example:

secrets {
  userID  = "admin"
  userKey = "AQDsIoxgHqpe..ZdIzA=="
}
```

</details>

<details><summary>render ceph_rbd_csi output</summary>

```
$ nomad-pack render -var ceph_cluster_id=e4008158-522b-4fd7-aed8-62b5e79dd293 ./ceph_rbd_csi
ceph_rbd_csi/node.nomad:

job "ceph_rbd_node" {
  # you can run node plugins as service jobs as well, but this ensures
  # that all nodes in the DC have a copy.
  type = "system"
  namespace   = "default"
  region      = "global"
  datacenters = ["dc1"]

  group "nodes" {

    constraint {
      attribute = "${attr.kernel.name}"
      value     = "linux"
    }
    constraint {
      attribute = "${attr.driver.docker.privileged.enabled}"
      value     = true
    }

    network {
      port "prometheus" {}
    }

    service {
      name = "prometheus"
      port = "prometheus"
      tags = ["ceph-csi"]
    }

    task "plugin" {
      driver = "docker"

      config {
        image = "quay.io/cephcsi/cephcsi:canary"

        args = [
          "--drivername=rbd.csi.ceph.com",
          "--v=5",
          "--type=rbd",
          "--nodeserver=true",
          "--nodeid=${NODE_ID}",
          "--instanceid=${POD_ID}",
          "--endpoint=${CSI_ENDPOINT}",
          "--metricsport=${NOMAD_PORT_prometheus}",
        ]

        privileged = true
        ports      = ["prometheus"]
      }

      template {
        data = <<-EOT
POD_ID=${NOMAD_ALLOC_ID}
NODE_ID=${node.unique.id}
CSI_ENDPOINT=unix://csi/csi.sock
EOT

        destination = "${NOMAD_TASK_DIR}/env"
        env         = true
      }

      csi_plugin {
        id        = "rbd.csi.ceph.com"
        type      = "node"
        mount_dir = "/csi"
      }
      resources {
        cpu    = 256
        memory = 256
      }

    }
  }
}

ceph_rbd_csi/controller.nomad:

job "ceph_rbd_controller" {

  namespace   = "default"
  region      = "global"
  datacenters = ["dc1"]

  group "controllers" {

    constraint {
      attribute = "${attr.kernel.name}"
      value     = "linux"
    }

    network {
      port "prometheus" {}
    }

    service {
      name = "prometheus"
      port = "prometheus"
      tags = ["ceph-csi"]
    }

    task "plugin" {
      driver = "docker"

      config {
        image = "quay.io/cephcsi/cephcsi:canary"

        args = [
          "--drivername=rbd.csi.ceph.com",
          "--v=5",
          "--type=rbd",
          "--controllerserver=true",
          "--nodeid=${NODE_ID}",
          "--instanceid=${POD_ID}",
          "--endpoint=${CSI_ENDPOINT}",
          "--metricsport=${NOMAD_PORT_prometheus}",
        ]

        ports      = ["prometheus"]

        # we need to be able to write key material to disk in this location
        mount {
          type     = "bind"
          source   = "secrets"
          target   = "/tmp/csi/keys"
          readonly = false
        }

        mount {
          type     = "bind"
          source   = "ceph-csi-config/config.json"
          target   = "/etc/ceph-csi-config/config.json"
          readonly = false
        }

      }

      template {
        data = <<-EOT
POD_ID=${NOMAD_ALLOC_ID}
NODE_ID=${node.unique.id}
CSI_ENDPOINT=unix://csi/csi.sock
EOT

        destination = "${NOMAD_TASK_DIR}/env"
        env         = true
      }

      # ceph configuration file
      template {

        data = <<EOF
[{
    "clusterID": "e4008158-522b-4fd7-aed8-62b5e79dd293",
    "monitors": [
        {{range $index, $service := service "ceph-mon"}}{{if gt $index 0}}, {{end}}"{{.Address}}"{{end}}
    ]
}]
EOF

        destination = "ceph-csi-config/config.json"
      }

      csi_plugin {
        id        = "rbd.csi.ceph.com"
        type      = "controller"
        mount_dir = "/csi"
      }
      resources {
        cpu    = 256
        memory = 256
      }

    }
  }
}

```

</details>


<details><summary>run ceph_rbd_csi output</summary>

```
$ nomad-pack run -var ceph_cluster_id=e4008158-522b-4fd7-aed8-62b5e79dd293 ./ceph_rbd_csi
  Evaluation ID: 0bcb04c4-0619-0d8c-a2c0-cdfc75aa4d7a
  Job 'ceph_rbd_controller' in pack deployment 'ceph_rbd_csi' registered successfully
  Evaluation ID: 5c4e991d-0df5-12a3-1680-a1bc33efd6be
  Job 'ceph_rbd_node' in pack deployment 'ceph_rbd_csi' registered successfully
Pack successfully deployed. Use ./ceph_rbd_csi to manage this this deployed instance with plan,
stop, destroy, or info

id        = "myvolume"
name      = "myvolume"
namespace = "default"
type      = "csi"
plugin_id = "rbd.csi.ceph.com"

capacity_min = "10GiB"
capacity_max = "30GiB"

capability {
  access_mode     = "single-node-writer"
  attachment_mode = "file-system"
}

capability {
  access_mode     = "single-node-writer"
  attachment_mode = "block-device"
}

# get this secret from the Ceph allocation:
# /etc/ceph/ceph.client.admin.keyring
secrets {
  userID  = "admin"
  userKey = "AQDsIoxgHqpe...spTbvwZdIzA=="
}

parameters {
  clusterID     = "e4008158-522b-4fd7-aed8-62b5e79dd293"
  pool          = "rbd"
  imageFeatures = "layering"
}
```

</details>

Resulting healthy plugins:

```
$ nomad plugin status rbd
ID                   = rbd.csi.ceph.com
Provider             = rbd.csi.ceph.com
Version              = canary
Controllers Healthy  = 2
Controllers Expected = 2
Nodes Healthy        = 2
Nodes Expected       = 2

Allocations
ID        Node ID   Task Group  Version  Desired  Status   Created    Modified
8d50c40b  0357bda7  controllers 2        run      running  1m26s ago  21s ago
9cda73da  37514e8a  controllers 2        run      running  1m26s ago  30s ago
d8e712d6  37514e8a  nodes       2        run      running  1m26s ago  30s ago
7101dd8e  0357bda7  nodes       2        run      running  1m26s ago  30s ago
```
