### PR TITLE
prometheus: Added support for dns in network and persistent volumes

### DIFF
--- a/packs/prometheus/README.md
+++ b/packs/prometheus/README.md
@@ -21,6 +21,7 @@ Prometheus.
 An example config is included in the alers_vars.nomad file.
 - `prometheus_task_resources` (object) - The resource to assign to the Prometheus task.
 - `prometheus_task_services` (object) - Configuration options of the Prometheus services and checks.
+- `prometheus_volume` (object) - Persistent Volume configuration for Prometheus
 
 ### `constraints` List of Objects
 
@@ -50,6 +51,7 @@ variable list of objects is shown below and uses a double dollar sign for escapi
 - `mode` (string "bridge") - Mode of the network.
 - `ports` (map<string|number> http:9090) - Specifies the port mapping for the Prometheus task. The
 map key indicates the port label, and the value is the Prometheus port inside the network namespace.
+- `dns` (map(list(string)) {}) - DNS configuration in network stanza
 
 ### `prometheus_task` Object
 
@@ -98,6 +100,22 @@ running against the Prometheus [management API][prometheus_management_api] healt
     check_timeout      = "1s",
   }
 ]
+```
+
+### `prometheus_volume` List of Objects
+
+- `type` (string) - Specifies the port to advertise for this service.
+- `source` (string) - Specifies the name this service will be advertised as in Consul.
+
+The default value for this variable configures no volume. A volume is mandatory for production setups.
+
+Example: (this is not the default value!)
+
+```hcl
+{
+  type = "host"
+  source = "prometheus"
+}
 ```
 
 [prometheus]: (https://prometheus.io/)

--- a/packs/prometheus/metadata.hcl
+++ b/packs/prometheus/metadata.hcl
@@ -7,5 +7,5 @@ pack {
   name        = "prometheus"
   description = "Prometheus is used to collect telemetry data and make it queryable."
   url         = "https://github.com/hashicorp/nomad-pack-community-registry/tree/main/prometheus"
-  version     = "0.0.1"
+  version     = "0.1.0"
 }

--- a/packs/prometheus/variables.hcl
+++ b/packs/prometheus/variables.hcl
@@ -43,13 +43,23 @@ variable "prometheus_group_network" {
   type        = object({
     mode  = string
     ports = map(number)
+    dns = map(list(string))
   })
   default = {
     mode  = "bridge",
     ports = {
       "http" = 9090,
     },
+    dns = {}
   }
+}
+
+variable "prometheus_volume" {
+  description = "The Volume for Prometheus persistent data"
+  type = object({
+    type    = string
+    source = string
+  })
 }
 
 variable "prometheus_task" {


### PR DESCRIPTION
This is a breaking change when prometheus_group_network has been
modified, due to chnaged structure in
prometheus_group_network. See new default for changes:

```
mode  = "bridge",
ports = {
  "http" = 9090,
},
dns = {}
```

Please confirm the following if submitting a new pack:

## New Pack Checklist
- [x] The README includes any information necessary to run the application that is not encoded in the pack itself.
- [x] The pack renders properly with `nomad-pack render <NAME>`
- [x] The pack plans properly with `nomad-pack plan <NAME>`
- [x] The pack runs properly with `nomad-pack runs <NAME>`
- [x] If applicable, a screenshot of the running application is attached to the PR.
- [x] The default variable values result in a syntactically valid pack.
- [x] Non-default variables values have been tested. Conditional code paths in the template have been tested, and confirmed to render/plan properly.
- [x] If applicable, the pack includes constraints necessary to run the pack safely (I.E. a linux-only constraint for applications that require linux).