### PR TITLE
traefik: fix service tags and service check path

### DIFF
--- a/packs/traefik/templates/traefik.nomad.tpl
+++ b/packs/traefik/templates/traefik.nomad.tpl
@@ -116,11 +116,14 @@ EOF
       service {
         name = [[ $service.service_name | quote ]]
         port = [[ $service.service_port_label | quote ]]
+        tags = [[ $service.service_tags | toStringList ]]
 
         [[- if $service.check_enabled ]]
         check {
           type     = [[ $service.check_type | quote ]]
+          [[- if $service.check_path ]]
           path     = [[ $service.check_path | quote ]]
+          [[- end ]]
           interval = [[ $service.check_interval | quote ]]
           timeout  = [[ $service.check_timeout | quote ]]
         }


### PR DESCRIPTION
Render service tags set in `traefik_task_services[*].service_tags` into
the template.

Check for empty `traefik_task_services[*].check_path` before rendering
since this is an optional config.

Please confirm the following if submitting a new pack:

## New Pack Checklist
- [x] The README includes any information necessary to run the application that is not encoded in the pack itself.
- [x] The pack renders properly with `nomad-pack render <NAME>`
- [x] The pack plans properly with `nomad-pack plan <NAME>`
- [x] The pack runs properly with `nomad-pack runs <NAME>`
- [x] If applicable, a screenshot of the running application is attached to the PR.
- [x] The default variable values result in a syntactically valid pack.
- [x] Non-default variables values have been tested. Conditional code paths in the template have been tested, and confirmed to render/plan properly.
- [x] If applicable, the pack includes constraints necessary to run the pack safely (I.E. a linux-only constraint for applications that require linux).