### PR TITLE
fix grafana dns servers in template

### DIFF
--- a/packs/grafana/templates/grafana.nomad.tpl
+++ b/packs/grafana/templates/grafana.nomad.tpl
@@ -16,8 +16,8 @@ job [[ template "job_name" . ]] {
 
     [[- if .grafana.dns ]]
     dns {
-      [[- if .grafana.dns.source ]]
-        servers = [[ .grafana.dns.source | toPrettyJson ]]
+      [[- if .grafana.dns.servers ]]
+        servers = [[ .grafana.dns.servers | toPrettyJson ]]
       [[- end ]]
       [[- if .grafana.dns.searches ]]
         searches = [[ .grafana.dns.searches | toPrettyJson ]]


### PR DESCRIPTION
`grafana.dns.source` does not match with `variables.hcl` as follows

```
variable "dns" {
  description = ""
  type = object({
    servers   = list(string)
    searches = list(string)
    options = list(string)
  })
}
```