### PR TITLE
fix inconsistent temp port

### DIFF
--- a/packs/grafana/variables.hcl
+++ b/packs/grafana/variables.hcl
@@ -136,7 +136,7 @@ datasources:
   - name: Tempo
     type: tempo
     access: proxy
-    url: http://tempo.service.{{ env "NOMAD_DC" }}.consul:3400
+    url: http://tempo.service.{{ env "NOMAD_DC" }}.consul:3200
     uid: tempo
   - name: Loki
     type: loki


### PR DESCRIPTION
tempo uses `3200` as default port

tempo/variables.hcl

```
variable "http_port" {
  description = "The Nomad client port that routes to the tempo."
  type        = number
  default     = 3200
}
```