### PR TITLE
opentelemetry_collector - fix typo in 'additional_templates' variable's object definition

### DIFF
--- a/packs/opentelemetry_collector/CHANGELOG.md
+++ b/packs/opentelemetry_collector/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- fix typo in `additional_templates` variable's object definition
+
 ## 0.0.2 (May 17, 2022)
 
 - Update OpenTelemery Collector image to 0.50.0 and add configs for Traefik with HTTP and gRPC. [[GH-128](https://github.com/hashicorp/nomad-pack-community-registry/pull/128)]

--- a/packs/opentelemetry_collector/variables.hcl
+++ b/packs/opentelemetry_collector/variables.hcl
@@ -189,7 +189,7 @@ variable "additional_templates" {
   description = "Additional job templates: access Consul KV, or the Vault KV or secrets engine. 'data' and 'destination' are required."
   type = list(object({
     data          = string
-    desination    = string
+    destination   = string
     change_mode   = string
     change_signal = string
     env           = bool


### PR DESCRIPTION
Reported by @ahjohannessen