### PR TITLE
Adds workflows for HashiCorp Developer integrations library

### DIFF
--- a/.github/scripts/files-to-identifiers.sh
+++ b/.github/scripts/files-to-identifiers.sh
@@ -1,0 +1,25 @@
+# #!/usr/bin/env bash
+#
+# This script coerces a list of input files that have been changed
+# into a list of integration identifiers. If a pack file is passed in
+# but the pack does not have an integration identifier specified,
+# nothing is returned. If multiple files of a single pack are passed in,
+# only one instance of the packs identifier will be returned.
+changedFiles=$(while IFS= read line; do echo "$line"; done)
+changedDirs=$(echo "$changedFiles" | sed -E 's/packs\/([^\/]*).*/\1/g')
+changedDirsUniq=$(echo "$changedDirs" | sort | uniq)
+
+# For each unique directory passed in
+for changed_dir in $(echo $changedDirsUniq); do
+  # Verify that the `metadata.hcl` file exists
+  metadataFile="./packs/$changed_dir/metadata.hcl"
+  if [[ -f "$metadataFile" ]]; then
+      # Verify that the `identifier` is specified
+      identifierLine="$(cat "$metadataFile" | grep "identifier.*=.*\".*\"")"
+      if [[ "$identifierLine" != "" ]]; then
+          # Parse out the `identifier` value
+          identifier="$(echo "$identifierLine" | sed -E 's/.*\"(.*)\"/\1/g')"
+          echo "$identifier"
+      fi
+  fi
+done

--- a/.github/scripts/version-from-identifier.sh
+++ b/.github/scripts/version-from-identifier.sh
@@ -1,0 +1,7 @@
+# #!/usr/bin/env bash
+metadataFile="$(grep -R "\"$1\"" ./packs | cut -d ' ' -f1 | sed 's/:.*//g')"
+if [[ -f "$metadataFile" ]]; then
+  versionLine="$(cat "$metadataFile" | grep "version.*=.*\".*\"")"
+  version="$(echo "$versionLine" | sed -E 's/.*\"(.*)\"/\1/g')"
+  echo $version
+fi

--- a/.github/workflows/notify-integration-release.yml
+++ b/.github/workflows/notify-integration-release.yml
@@ -1,0 +1,57 @@
+name: Notify Integration Release
+on:
+  push:
+    paths:
+      - "packs/**"
+    branches:
+      - main
+jobs:
+  determine_identifiers:
+    name: Determine Identifiers
+    runs-on: ubuntu-latest
+    outputs:
+      identifiers: ${{ steps.output_result.outputs.identifiers }}
+    steps:
+      - name: Checkout Nomad Pack Community Registry
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - id: determine_changed_files
+        name: Determine Changed Files
+        uses: jitterbit/get-changed-files@d06c756e3609dd3dd5d302dde8d1339af3f790f2 # v1
+      - id: output_result
+        run: |
+          matrixArray=$(
+            echo ${{ steps.determine_changed_files.outputs.all }} \
+              | ./.github/scripts/files-to-identifiers.sh \
+              | jq --raw-input --slurp  'split("\n") | map(select(. != ""))' \
+              | jq -c .
+          )
+          echo "identifiers=$matrixArray" >> "$GITHUB_OUTPUT"
+
+  notify_release:
+    runs-on: ubuntu-latest
+    needs: determine_identifiers
+    strategy:
+      matrix:
+        integration_identifier: ${{fromJson(needs.determine_identifiers.outputs.identifiers)}}
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+      - id: calculate_version
+        name: Calculate Version
+        run: |
+          version="$(./.github/scripts/version-from-identifier.sh ${{ matrix.integration_identifier }})"
+          echo "Computed Version: $version"
+          echo "releaseVersion=$version" >> "$GITHUB_OUTPUT"
+      - name: Checkout integration-release-action
+        uses: actions/checkout@v3
+        with:
+          repository: hashicorp/integration-release-action
+          path: ./integration-release-action
+      - name: Notify Release
+        uses: ./integration-release-action
+        with:
+          integration_identifier: ${{ matrix.integration_identifier }}
+          release_version: ${{ steps.calculate_version.outputs.releaseVersion }}
+          release_sha: ${{ github.ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          integration_strategy: 'nomad-pack'


### PR DESCRIPTION
Introduces workflows for notifying the [HashiCorp Developer](https://developer.hashicorp.com/) integrations library whenever there is an update to a Pack.

Nomad does not have an integrations library on HashiCorp Developer yet  (e.x. [Waypoint's](https://developer.hashicorp.com/waypoint/integrations)), but soon will, which will include the Packs inside of this registry.