### PR TITLE
Fix a bug which prevented multi-integration syncs

### DIFF
--- a/.github/workflows/notify-integration-release.yml
+++ b/.github/workflows/notify-integration-release.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           matrixArray=$(
             echo ${{ steps.determine_changed_files.outputs.all }} \
+              | sed 's/ /\n/g' \
               | ./.github/scripts/files-to-identifiers.sh \
               | jq --raw-input --slurp  'split("\n") | map(select(. != ""))' \
               | jq -c .


### PR DESCRIPTION
The re-echoing of the output coerced the results to a single line, which prevented each integration update from being read in.