### PR TITLE
hashicups: Update templates to v2 format

### DIFF
--- a/packs/hashicups/outputs.tpl
+++ b/packs/hashicups/outputs.tpl
@@ -1,6 +1,6 @@
-Congratulations on deploying [[ .nomad_pack.pack.name ]]! 
+Congratulations on deploying [[ meta "pack.name" . ]]! 
 
-Navigate to the HashiCups UI on port [[ .hashicups.nginx_port ]] of the Nomad client running the job.
+Navigate to the HashiCups UI on port [[ var "nginx_port" . ]] of the Nomad client running the job.
 
 You can find the allocation ID with:
 nomad job status hashicups | grep -A 3 -i allocations

--- a/packs/hashicups/templates/_helpers.tpl
+++ b/packs/hashicups/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+// allow nomad-pack to set the job name
+
+[[- define "job_name" -]]
+[[ meta "pack.name" . | quote ]]
+[[- end -]]
+
+// only deploys to a region if specified
+
+[[ define "region" -]]
+[[- if var "region" . -]]
+region = [[ var "region" . | quote ]]
+[[- end -]]
+[[- end -]]


### PR DESCRIPTION
This updates the hashicups pack to use the new v2 template format to make it a better example for how you should template packs with the current version of nomad-pack.