### PR TITLE
TFE FDO on Nomad GA release

### DIFF
--- a/packs/tfe_fdo_nomad/CHANGELOG.md
+++ b/packs/tfe_fdo_nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
 # 0.1.0
 
 - Initial release
+
+# 0.1.1
+
+- Now generally available.
+- Nomad Task API replaces Nomad Job API making the integration simpler.
+- Agent Job ID is now configurable with variable `tfe_agent_job_id`.

--- a/packs/tfe_fdo_nomad/README.md
+++ b/packs/tfe_fdo_nomad/README.md
@@ -1,9 +1,4 @@
-<Note title="Nomad in beta">
-    Running Terraform Enterprise on Nomad is still in beta. Do not deploy beta features in
-    production environments.
-</Note>
-
-# Nomad pack for Terraform Enterprise FDO (Beta)
+# Nomad pack for Terraform Enterprise FDO
 
 This pack deploys Terraform Enterprise on Nomad. This includes running a Terraform Enterprise service job and Terraform Enterprise agent batch job.
 
@@ -75,15 +70,6 @@ To apply the policy run following bash command:
     # Object storage access key. Mapped to the TFE_OBJECT_STORAGE_S3_SECRET_ACCESS_KEY environment variable.
     s3_secret_key = ""
 
-    # The field should contain the base64 encoded value of the Nomad CA. Mapped to the TFE_RUN_PIPELINE_NOMAD_TLS_CONFIG_CA_CERT environment variable.
-    nomad_ca_cert = ""
-
-    # The field should contain the base64 encoded value of the Nomad cert. Mapped to the TFE_RUN_PIPELINE_NOMAD_TLS_CONFIG_CLIENT_CERT environment variable.
-    nomad_cert = ""
-
-    # The field should contain the base64 encoded value of the Nomad cert's key. Mapped to the TFE_RUN_PIPELINE_NOMAD_TLS_CONFIG_CLIENT_KEY environment variable.
-    nomad_cert_key = ""
-
     # TFE Redis password. Mapped to the TFE_REDIS_PASSWORD environment variable.
     redis_password = ""
 
@@ -121,7 +107,8 @@ These variables may be set to change the behavior of the TFE. Note that some of 
 
 | Name                                         | Required | Default                                      | Comments                                                                                                                                                                                                                                                                            |
 |----------------------------------------------|----------|----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `job_name`                                   | no       | `"tfe-job"`                                  | Override the Nomad job name.                                                                                                                                                                                                                                                        |
+| `job_name`                                   | no       | `"tfe-job"`                                  | Override the TFE job name.                                                                                                                                                                                                                                                          |
+| `tfe_agent_job_id`                           | no       | `"tfe-agent-job"`                            | Override the TFE Agent job name.                                                                                                                                                                                                                                                    |
 | `datacenters`                                | no       | `["*"]`                                      | Nomad datacenters where the task in the jobs will be spread.                                                                                                                                                                                                                        |
 | `tfe_namespace`                              | no       | `"terraform-enterprise"`                     | Nomad namespace where TFE image will be run as a Nomad task.                                                                                                                                                                                                                        |
 | `tfe_port`                                   | no       | `8443`                                       | HTTPS port to expose for TFE task.                                                                                                                                                                                                                                                  |
@@ -133,7 +120,6 @@ These variables may be set to change the behavior of the TFE. Note that some of 
 | `tfe_database_name`                          | no       | `"tfe"`                                      | TFE database name.                                                                                                                                                                                                                                                                  |
 | `tfe_database_parameters`                    | no       | `"sslmode=require"`                          | TFE database server parameters for the connection URI.                                                                                                                                                                                                                              |
 | `tfe_object_storage_type`                    | no       | `"s3"`                                       | Type of object storage to use. Must be one of s3, azure, or google.                                                                                                                                                                                                                 |
-| `tfe_run_pipeline_nomad_address`             | yes      | `""`                                         | The server address of Nomad where TFE is being deployed.                                                                                                                                                                                                                            |
 | `tfe_object_storage_s3_bucket`               | no       | `"tfe"`                                      | The bucket name of the S3 compatible object storage being used.                                                                                                                                                                                                                     |
 | `tfe_object_storage_s3_region`               | no       | `"us-west-2"`                                | S3 region.                                                                                                                                                                                                                                                                          |
 | `tfe_object_storage_s3_use_instance_profile` | no       | `false`                                      | Whether to use the instance profile for authentication.                                                                                                                                                                                                                             |
@@ -152,7 +138,6 @@ These variables may be set to change the behavior of the TFE. Note that some of 
 | `tfe_image`                                  | no       | `"hashicorp/terraform-enterprise:v202401-2"` | TFE image and tag to download and run.                                                                                                                                                                                                                                              |
 | `tfe_image_registry_username`                | no       | `"terraform"`                                | The user name for the registry where the TFE image is hosted.                                                                                                                                                                                                                       |
 | `tfe_image_server_address`                   | no       | `"images.releases.hashicorp.com"`            | The server address of the registry where TFE image is hosted.                                                                                                                                                                                                                       |
-| `tfe_run_pipeline_nomad_tls_config_insecure` | no       | `false`                                      | mTLS between Nomad and TFE when set to false.                                                                                                                                                                                                                                       |
 | `tfe_agent_namespace`                        | no       | `"tfe-agents"`                               | Nomad namespace for TFE Agents to run.                                                                                                                                                                                                                                              |
 | `tfe_agent_image`                            | no       | `"hashicorp/tfc-agent:latest"`               | TFE Agent image and tag to download and run.                                                                                                                                                                                                                                        |
 | `tfe_vault_cluster_port`                     | no       | `8201`                                       | Vault cluster port which needs to exposed from the TFE container.                                                                                                                                                                                                                   |

--- a/packs/tfe_fdo_nomad/metadata.hcl
+++ b/packs/tfe_fdo_nomad/metadata.hcl
@@ -8,5 +8,5 @@ pack {
   name        = "tfe_fdo_nomad"
   url         = "https://github.com/hashicorp/nomad-pack-community-registry/tfe_fdo_nomad"
   description = "Terraform Enterprise"
-  version     = "0.1.0"
+  version     = "0.1.1"
 }

--- a/packs/tfe_fdo_nomad/templates/tfe.agent.nomad.tpl
+++ b/packs/tfe_fdo_nomad/templates/tfe.agent.nomad.tpl
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-job "tfe-agent-job" {
+job [[ .tfe_fdo_nomad.tfe_agent_job_id | quote ]] {
   type      = "batch"
   namespace = [[ .tfe_fdo_nomad.tfe_agent_namespace | quote ]]
   constraint {

--- a/packs/tfe_fdo_nomad/templates/tfe.nomad.tpl
+++ b/packs/tfe_fdo_nomad/templates/tfe.nomad.tpl
@@ -91,39 +91,6 @@ EOF
       }
 
       template {
-        destination = "${NOMAD_SECRETS_DIR}/nomad_ca_cert.pem"
-        change_mode = "restart"
-        splay       = "60s"
-        data        = <<EOF
-{{- with nomadVar "nomad/jobs/[[ .tfe_fdo_nomad.job_name ]]" -}}
-  {{ base64Decode .nomad_ca_cert.Value }}
-{{- end -}}
-EOF
-      }
-
-      template {
-        destination = "${NOMAD_SECRETS_DIR}/nomad_cert.pem"
-        change_mode = "restart"
-        splay       = "60s"
-        data        = <<EOF
-{{- with nomadVar "nomad/jobs/[[ .tfe_fdo_nomad.job_name ]]" -}}
-  {{ base64Decode .nomad_cert.Value }}
-{{- end -}}
-EOF
-      }
-
-      template {
-        destination = "${NOMAD_SECRETS_DIR}/nomad_cert_key.pem"
-        change_mode = "restart"
-        splay       = "60s"
-        data        = <<EOF
-{{- with nomadVar "nomad/jobs/[[ .tfe_fdo_nomad.job_name ]]" -}}
-  {{ base64Decode .nomad_cert_key.Value }}
-{{- end -}}
-EOF
-      }
-
-      template {
         destination = "${NOMAD_SECRETS_DIR}/secrets.env"
         env         = true
         change_mode = "restart"
@@ -153,14 +120,11 @@ EOF
       env {
         
         TFE_RUN_PIPELINE_DRIVER = "nomad"
-        TFE_RUN_PIPELINE_NOMAD_ADDRESS             = [[ .tfe_fdo_nomad.tfe_run_pipeline_nomad_address | quote ]]
-        TFE_RUN_PIPELINE_NOMAD_TLS_CONFIG_INSECURE = [[ .tfe_fdo_nomad.tfe_run_pipeline_nomad_tls_config_insecure | quote ]]
-        TFE_RUN_PIPELINE_NOMAD_TLS_CONFIG_CA_CERT = "${NOMAD_SECRETS_DIR}/nomad_ca_cert.pem"
-        TFE_RUN_PIPELINE_NOMAD_TLS_CONFIG_CLIENT_CERT = "${NOMAD_SECRETS_DIR}/nomad_cert.pem"
-        TFE_RUN_PIPELINE_NOMAD_TLS_CONFIG_CLIENT_KEY = "${NOMAD_SECRETS_DIR}/nomad_cert_key.pem"
         TFE_DISK_CACHE_VOLUME_NAME                 = "${NOMAD_TASK_DIR}/terraform-enterprise-cache"
 
         TFE_OPERATIONAL_MODE = "active-active"
+
+        TFE_RUN_PIPELINE_NOMAD_AGENT_JOB_ID = [[ .tfe_fdo_nomad.tfe_agent_job_id | quote ]]
 
         TFE_DATABASE_USER = [[ .tfe_fdo_nomad.tfe_database_user | quote ]]
         TFE_DATABASE_HOST       = [[ .tfe_fdo_nomad.tfe_database_host | quote ]]

--- a/packs/tfe_fdo_nomad/variables.hcl
+++ b/packs/tfe_fdo_nomad/variables.hcl
@@ -4,6 +4,12 @@ variable "job_name" {
   default     = "tfe-job"
 }
 
+variable "tfe_agent_job_id" {
+  description = "The ID of the TFE agent job which overrides using the pack name"
+  type        = string
+  default     = "tfe-agent-job"
+}
+
 variable "tfe_namespace" {
   description = "The namespace for the tfe job to run."
   type        = string
@@ -158,7 +164,7 @@ variable "tfe_resource_memory" {
 variable "tfe_image" {
   description = "The terraform enterprise image that will be used to deploy TFE"
   type        = string
-  default     = "hashicorp/terraform-enterprise:v202401-2"
+  default     = "hashicorp/terraform-enterprise:v202408-1"
 }
 
 variable "tfe_image_registry_username" {
@@ -171,17 +177,6 @@ variable "tfe_image_server_address" {
   description = "The server address to be used to fetch the terraform enterprise image from the registry."
   type        = string
   default     = "images.releases.hashicorp.com"
-}
-
-variable "tfe_run_pipeline_nomad_address" {
-  description = "The Nomad server address to be used by TFE to spin up agent jobs."
-  type        = string
-}
-
-variable "tfe_run_pipeline_nomad_tls_config_insecure" {
-  description = "The tls config settings for communication between Nomad and TFE"
-  type        = bool
-  default     = false
 }
 
 variable "tfe_agent_namespace" {


### PR DESCRIPTION
- Updated TFE version to use GA release version.
- Using Nomad Task API instead of Nomad Job API.
- Nomad certs are no longer required.
- TFE Agent job ID now configurable.

Please confirm the following if submitting a new pack:

## New Pack Checklist
- [x] The README includes any information necessary to run the application that is not encoded in the pack itself.
- [x] The pack renders properly with `nomad-pack render <NAME>`
- [x] The pack plans properly with `nomad-pack plan <NAME>`
- [x] The pack runs properly with `nomad-pack runs <NAME>`
- [ ] If applicable, a screenshot of the running application is attached to the PR.
- [x] The default variable values result in a syntactically valid pack.
- [x] Non-default variables values have been tested. Conditional code paths in the template have been tested, and confirmed to render/plan properly.
- [x] If applicable, the pack includes constraints necessary to run the pack safely (I.E. a linux-only constraint for applications that require linux).