### PR TITLE
CI validation

### DIFF
--- a/.github/workflows/validate-packs.yml
+++ b/.github/workflows/validate-packs.yml
@@ -1,0 +1,40 @@
+name: Validate Packs
+
+on:
+  pull_request:
+    paths:
+      - "packs/**"
+      - "ci/**"
+      - ".github/workflows/validate-packs.yml"
+
+jobs:
+  validate_packs:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+
+      - name: Get changed files
+        # https://github.com/hanseltimeindustries/get-changed-files
+        uses: hanseltimeindustries/get-changed-files/@0b9ab9b0bdbe9384ab0202b4c119fd8f88747335 # v1.1.2
+        id: changed_files
+
+      - name: Install nomad-pack
+        uses: hashicorp/setup-nomad-pack@main
+        with:
+          version: latest
+
+      - name: Install nomad
+        uses: hashicorp/setup-nomad@main
+        with:
+          version: latest
+
+      - name: Run validation script
+        run: |
+          tr ' ' '\n' <<< "${{ steps.changed_files.outputs.added_modified }}" \
+          | grep -Eo 'packs/[0-9a-zA-Z_]+' | sort | uniq \
+          | while read pack; do
+            echo "::group::$pack"
+            ./ci/validate.sh "$pack"
+            echo "::endgroup::"
+          done

--- a/ci/validate.sh
+++ b/ci/validate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+set -u
+
+if [ $# -lt 1 ]; then
+    cat <<EOF
+Validate pack(s) with:
+ * nomad-pack render
+ * nomad fmt
+ * nomad validate
+
+Usage: $0 ./packs/path-to-pack
+
+Packs render to the ./rendered/ dir for inspection
+if validation fails.
+EOF
+    exit 1
+fi
+
+path="$1"
+pack="$(basename "$1")" # lazy assumption
+
+set -exo pipefail
+
+mkdir -p rendered
+
+validate() {
+    local render_flags="${1:-}"
+    # `nomad-pack render` catches pack templating errors
+    nomad-pack render $render_flags -o ./rendered "$path"
+
+    find "./rendered/$pack" -type f -name '*.nomad' -or -name '*.hcl' \
+    | while read -r job; do
+        # `nomad fmt` catches syntax errors in the rendered hcl
+        nomad fmt "$job"
+        # `nomad validate` catches semantic jobspec issues,
+        # especially if run against a live nomad agent.
+        nomad validate "$job"
+    done
+
+    # if all goes well, delete reference files
+    rm -rf "./rendered/$pack"
+}
+
+# run with different var files, if present
+if [ -d "$path/.ci" ]; then
+    find "$path/.ci" -type f -name 'vars-*.hcl' \
+    | while read -r var_file; do
+        cat "$var_file"
+        validate "--var-file $var_file"
+    done
+else
+    # otherwise, validate with no vars
+    validate
+fi

--- a/packs/boundary/.ci/vars-required.hcl
+++ b/packs/boundary/.ci/vars-required.hcl
@@ -1,0 +1,3 @@
+postgres_address  = "test-host"
+postgres_username = "test-user"
+postgres_password = "test-pass"

--- a/packs/csi_openstack_cinder/.ci/vars-required.hcl
+++ b/packs/csi_openstack_cinder/.ci/vars-required.hcl
@@ -1,0 +1,2 @@
+# this file needs to actually exist
+cloud_conf_file = "./packs/csi_openstack_cinder/metadata.hcl"

--- a/packs/democratic_csi_nfs/.ci/vars-required.hcl
+++ b/packs/democratic_csi_nfs/.ci/vars-required.hcl
@@ -1,0 +1,3 @@
+nfs_share_host            = "test-localhost"
+nfs_controller_mount_path = "/tmp/test-controller-mount"
+nfs_share_base_path       = "/test-export"

--- a/packs/tfc_agent/.ci/vars-required.hcl
+++ b/packs/tfc_agent/.ci/vars-required.hcl
@@ -1,0 +1,1 @@
+agent_token = "not a real token"

--- a/packs/tfe_fdo_nomad/.ci/vars-required.hcl
+++ b/packs/tfe_fdo_nomad/.ci/vars-required.hcl
@@ -1,0 +1,11 @@
+tfe_hostname      = "localhost"
+tfe_database_host = "localhost"
+tfe_redis_host    = "localhost"
+
+tfe_object_storage_s3_endpoint      = "s3-fakery"
+tfe_object_storage_s3_access_key_id = "s3-fake-id"
+
+# these aren't strictly required,
+# but default to non-existent namespaces
+tfe_namespace       = "default"
+tfe_agent_namespace = "default"


### PR DESCRIPTION
Adds automatic validation for packs on PR.

This does not make sure that they actually really truly work!  But that they can:
 *  `nomad-pack render` for template syntax, optionally with variables (which are sometimes required)
 * `nomad fmt` for HCL syntax
 * `nomad validate` for some semantic jobspec stuff

The workflow only targets changed packs, but the whole repo passes with

```
ls packs/ | while read p; do
  ./ci/validate.sh packs/$p || break
done
```